### PR TITLE
Mesh Export option update [PoC, don't merge]

### DIFF
--- a/Assets/Runtime/Scripts/MeshSyncServer.cs
+++ b/Assets/Runtime/Scripts/MeshSyncServer.cs
@@ -2331,7 +2331,15 @@ namespace UTJ.MeshSync
             }
 
             var dstPath = assetPath + "/" + mesh.name + ".asset";
-            CreateAsset(instancedMesh, dstPath);
+
+            // avoid overwrite existing mesh file, update mesh data instead
+            var savedMesh = AssetDatabase.LoadAssetAtPath<Mesh>(dstPath);
+            if (savedMesh != null) {
+                savedMesh.Clear();
+                EditorUtility.CopySerialized(instancedMesh, savedMesh);
+            } else {
+                CreateAsset(instancedMesh, dstPath);
+            }
 
             if (m_logging)
                 Debug.Log("exported mesh " + dstPath);


### PR DESCRIPTION
As described in #67, I tried to add an option that allows Y-up mesh export, it works for my cases.

<img width="302" alt="Screen Shot 2019-04-28 at 21 37 51" src="https://user-images.githubusercontent.com/1484279/56865206-e91ac980-69fd-11e9-9f7b-8a3983a30f0a.png">

Things to note:

- This option should preserve correct vertices/normals/tangents/uvs.
- This option doesn't preserve correct bind poses (I am not quite sure how to convert them).
- There is an additional commit to avoid overwriting mesh asset file, so that existing reference to the mesh is preserved, I am unsure if it has any drawbacks (I noticed [you had the same issue 2 years ago](https://answers.unity.com/questions/678967/why-meshes-require-a-restart-when-using-copyserial.html), so perhaps it didn't work for some reasons?)