### PR TITLE
chore: building plugins for Max

### DIFF
--- a/Plugin~/MeshSyncClient3dsMax.vcxproj
+++ b/Plugin~/MeshSyncClient3dsMax.vcxproj
@@ -62,12 +62,12 @@
   <ImportGroup Label="ExtensionSettings">
   </ImportGroup>
   <PropertyGroup>
-    <IncludePath>$(SolutionDir);$(SolutionDir)External\3ds Max opt\include;$(SolutionDir)External\Poco\include;$(MAX_INCLUDE_DIR);$(IncludePath)</IncludePath>
+    <IncludePath>$(SolutionDir);$(SolutionDir)External\Poco\include;$(MAX_INCLUDE_DIR);$(MAX_SAMPLES_DIR);$(IncludePath)</IncludePath>
     <OutDir>$(SolutionDir)_out\$(Platform)_$(Configuration)\$(ProjectName)$(MAX_VERSION)\</OutDir>
     <IntDir>$(SolutionDir)_tmp\$(ProjectName)$(MAX_VERSION)_$(Platform)_$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Platform)'=='x64'">
-    <LibraryPath>$(SolutionDir)External\3ds Max opt\lib64;$(SolutionDir)External\Poco\lib64;$(SolutionDir)External\zstd\lib64;$(MAX_LIB_DIR);$(LibraryPath)</LibraryPath>
+    <LibraryPath>$(SolutionDir)External\3ds Max opt\lib64;$(SolutionDir)External\Poco\lib64;$(SolutionDir)External\zstd\lib64;$(MAX_LIB_DIR);$(MAX_MORPHER_LIB_DIR);$(LibraryPath)</LibraryPath>
   </PropertyGroup>
   <PropertyGroup>
     <TargetExt>.dlu</TargetExt>

--- a/Plugin~/MeshSyncClient3dsMax/pch.h
+++ b/Plugin~/MeshSyncClient3dsMax/pch.h
@@ -37,7 +37,7 @@
 #include <maxscript/util/listener.h>
 #include <maxscript/foundation/numbers.h>
 #include <maxscript/macros/define_instantiation_functions.h>
-#include <MorpherApi.h>
+#include <modifiers/morpher/include/MorpherApi.h>
 #include <Scene/IPhysicalCamera.h>
 #if MAX_PRODUCT_YEAR_NUMBER >= 2018
     #include <CATAPI/CATClassID.h>

--- a/Plugin~/MeshSync_3dsMax.bat
+++ b/Plugin~/MeshSync_3dsMax.bat
@@ -1,7 +1,6 @@
 set MAX_VERSION=2020
-set "INCLUDE_VAR=MAX_INCLUDE_DIR_%MAX_VERSION%"
-set "LIB_VAR=MAX_LIB_DIR_%MAX_VERSION%"
+set "MAX_SDK_PATH=MAX_SDK_%MAX_VERSION%"
 
-call set MAX_INCLUDE_DIR=%%%INCLUDE_VAR%%%
-call set MAX_LIB_DIR=%%%LIB_VAR%%%
+call set MAX_INCLUDE_DIR=%%%MAX_SDK_PATH%%%\include
+call set MAX_LIB_DIR=%%%MAX_SDK_PATH%%%\lib\x64\Release
 MeshSync_3dsMax.sln

--- a/Plugin~/MeshSync_3dsMax.bat
+++ b/Plugin~/MeshSync_3dsMax.bat
@@ -7,7 +7,6 @@ call set MAX_LIB_DIR=%%%MAX_SDK_PATH%%%\lib\x64\Release
 call set MAX_SAMPLES_DIR=%%%MAX_SDK_PATH%%%\samples
 call set MAX_MORPHER_LIB_DIR=%%%MAX_SDK_PATH%%%\samples\modifiers\morpher\Lib\x64\Release
 
-echo %MAX_MORPHER_LIB_DIR%\Morpher.lib
 if not exist "%MAX_MORPHER_LIB_DIR%\Morpher.lib" (
     toolchain.bat
     msbuild "%MAX_SAMPLES_DIR%\modifiers\morpher\morpher.vcxproj" /t:Build /p:Configuration=Release /p:Platform=x64 /m /nologo /p:PlatformToolset=v141 /p:WindowsTargetPlatformVersion=%WindowsSDKVersion%

--- a/Plugin~/MeshSync_3dsMax.bat
+++ b/Plugin~/MeshSync_3dsMax.bat
@@ -1,6 +1,16 @@
 set MAX_VERSION=2020
-set "MAX_SDK_PATH=MAX_SDK_%MAX_VERSION%"
+set "MAX_SDK_PATH=ADSK_3DSMAX_SDK_%MAX_VERSION%"
 
+echo off
 call set MAX_INCLUDE_DIR=%%%MAX_SDK_PATH%%%\include
 call set MAX_LIB_DIR=%%%MAX_SDK_PATH%%%\lib\x64\Release
+call set MAX_SAMPLES_DIR=%%%MAX_SDK_PATH%%%\samples
+call set MAX_MORPHER_LIB_DIR=%%%MAX_SDK_PATH%%%\samples\modifiers\morpher\Lib\x64\Release
+
+echo %MAX_MORPHER_LIB_DIR%\Morpher.lib
+if not exist "%MAX_MORPHER_LIB_DIR%\Morpher.lib" (
+    toolchain.bat
+    msbuild "%MAX_SAMPLES_DIR%\modifiers\morpher\morpher.vcxproj" /t:Build /p:Configuration=Release /p:Platform=x64 /m /nologo /p:PlatformToolset=v141 /p:WindowsTargetPlatformVersion=%WindowsSDKVersion%
+)
+
 MeshSync_3dsMax.sln

--- a/Plugin~/build_max.bat
+++ b/Plugin~/build_max.bat
@@ -11,10 +11,16 @@ exit /B 0
 
 :Build
     set MAX_VERSION=%~1
-    set "MAX_SDK_PATH=MAX_SDK_%MAX_VERSION%"
+    set "MAX_SDK_PATH=ADSK_3DSMAX_SDK_%MAX_VERSION%"
     
     call set MAX_INCLUDE_DIR=%%%MAX_SDK_PATH%%%\include
     call set MAX_LIB_DIR=%%%MAX_SDK_PATH%%%\lib\x64\Release
+    call set MAX_SAMPLES_DIR=%%%MAX_SDK_PATH%%%\samples
+    call set MAX_MORPHER_LIB_DIR=%%%MAX_SDK_PATH%%%\samples\modifiers\morpher\Lib\x64\Release
+
+    if not exist "%MAX_MORPHER_LIB_DIR%\Morpher.lib" (
+        msbuild "%MAX_SAMPLES_DIR%\modifiers\morpher\morpher.vcxproj" /t:Build /p:Configuration=Release /p:Platform=x64 /m /nologo /p:PlatformToolset=v141 /p:WindowsTargetPlatformVersion=%WindowsSDKVersion%
+    )
           
     msbuild MeshSyncClient3dsMax.vcxproj /t:Build /p:Configuration=Release /p:Platform=x64 /m /nologo
     IF %ERRORLEVEL% NEQ 0 (

--- a/Plugin~/build_max.bat
+++ b/Plugin~/build_max.bat
@@ -6,17 +6,16 @@ call :Build 2020
 call :Build 2019
 call :Build 2018
 call :Build 2017
-call :Build 2016
+rem call :Build 2016
 exit /B 0
 
 :Build
     set MAX_VERSION=%~1
-    set "INCLUDE_VAR=MAX_INCLUDE_DIR_%MAX_VERSION%"
-    set "LIB_VAR=MAX_LIB_DIR_%MAX_VERSION%"
+    set "MAX_SDK_PATH=MAX_SDK_%MAX_VERSION%"
     
-    call set MAX_INCLUDE_DIR=%%%INCLUDE_VAR%%%
-    call set MAX_LIB_DIR=%%%LIB_VAR%%%
-       
+    call set MAX_INCLUDE_DIR=%%%MAX_SDK_PATH%%%\include
+    call set MAX_LIB_DIR=%%%MAX_SDK_PATH%%%\lib\x64\Release
+          
     msbuild MeshSyncClient3dsMax.vcxproj /t:Build /p:Configuration=Release /p:Platform=x64 /m /nologo
     IF %ERRORLEVEL% NEQ 0 (
         pause

--- a/Plugin~/setup.bat
+++ b/Plugin~/setup.bat
@@ -8,7 +8,7 @@ IF NOT EXIST "7za.exe" (
 )
 
 echo "downloading external libararies..."
-powershell.exe -NoProfile -InputFormat None -ExecutionPolicy Bypass -Command "[System.Net.ServicePointManager]::SecurityProtocol=[System.Net.SecurityProtocolType]::Tls12; wget https://github.com/unity3d-jp/MeshSync/releases/download/20171228/External.7z -OutFile External.7z"
+powershell.exe -NoProfile -InputFormat None -ExecutionPolicy Bypass -Command "[System.Net.ServicePointManager]::SecurityProtocol=[System.Net.SecurityProtocolType]::Tls12; wget https://github.com/unity3d-jp/MeshSync/releases/download/20200123/External.7z -OutFile External.7z"
 7za.exe x -aos External.7z
 
 echo "downloading mqsdk470.zip ..."


### PR DESCRIPTION
- Simplify building plugins for Max, so that users do not need to specify environment variables.
- Use new External.7z
- Automatically build morpher.lib if the file doesn't exist.