### PR TITLE
Fix: Increased timeout time to allow internet based connection with m…

### DIFF
--- a/Plugin~/MeshSync/msClient.h
+++ b/Plugin~/MeshSync/msClient.h
@@ -21,7 +21,7 @@ public:
 
     // if failed, you can get reason by getErrorMessage()
     // (could not reach server, protocol version doesn't match, etc)
-    bool isServerAvailable(int timeout_ms = 100);
+    bool isServerAvailable(int timeout_ms = 1000);
 
     ScenePtr send(const GetMessage& mes);
     bool send(const SetMessage& mes);


### PR DESCRIPTION
The current version of meshsync only works if the latency between the host and client is less than 100ms (0.1 seconds). This pull request increase the time out to 1000ms (1 second). I have successfully being using this pull request with blender and has resolved this issue