### PR TITLE
fix: Blender plugin installation on Mac OSX

### DIFF
--- a/Editor/Scripts/DCCIntegration/Integrators/BlenderIntegrator.cs
+++ b/Editor/Scripts/DCCIntegration/Integrators/BlenderIntegrator.cs
@@ -110,7 +110,11 @@ internal class BlenderIntegrator : BaseDCCIntegrator {
             string[] files = System.IO.Directory.GetFiles(installedPluginDir, "*.so");
             if (files.Length > 0) {
                 foreach (string binaryPluginFile in files) {
-                    File.Delete(binaryPluginFile);                    
+                    try {
+                        File.Delete(binaryPluginFile);
+                    } catch (Exception e) {
+                        Debug.LogError("[MeshSync] Error when deleting previous plugin: " + binaryPluginFile);
+                    }
                 }
             }
 #endif            

--- a/Editor/Scripts/DCCIntegration/Integrators/BlenderIntegrator.cs
+++ b/Editor/Scripts/DCCIntegration/Integrators/BlenderIntegrator.cs
@@ -99,6 +99,20 @@ internal class BlenderIntegrator : BaseDCCIntegrator {
             );
             process.WaitForExit();
             
+            
+#if UNITY_EDITOR_OSX
+            //Delete plugin on mac to avoid errors of loading new plugin:
+            //Termination Reason: Namespace CODESIGNING, Code 0x2 
+            string installedPluginDir = Environment.GetFolderPath(Environment.SpecialFolder.Personal)
+                + "/Library/Application Support/Blender/2.83/scripts/addons/MeshSyncClientBlender";
+            string[] files = System.IO.Directory.GetFiles(installedPluginDir, "*.so");
+            if (files.Length > 0) {
+                foreach (string binaryPluginFile in files) {
+                    File.Delete(binaryPluginFile);                    
+                }
+            }
+#endif            
+            
             //Install
             const int PYTHON_EXIT_CODE = 10;
             process.StartInfo.Arguments = $"-b -P {installScriptPath} --python-exit-code {PYTHON_EXIT_CODE}";

--- a/Editor/Scripts/DCCIntegration/Integrators/BlenderIntegrator.cs
+++ b/Editor/Scripts/DCCIntegration/Integrators/BlenderIntegrator.cs
@@ -60,6 +60,7 @@ internal class BlenderIntegrator : BaseDCCIntegrator {
         }
       
         bool setupSuccessful = SetupAutoLoadPlugin(dccToolInfo.AppPath, 
+            dccToolInfo.DCCToolVersion,
             Path.GetFullPath(uninstallScriptPath), 
             Path.GetFullPath(installScriptPath)
         );
@@ -83,7 +84,8 @@ internal class BlenderIntegrator : BaseDCCIntegrator {
 //----------------------------------------------------------------------------------------------------------------------
 
     
-    bool SetupAutoLoadPlugin(string appPath, string uninstallScriptPath, string installScriptPath) {
+    bool SetupAutoLoadPlugin(string appPath, string dccToolVersion, 
+        string uninstallScriptPath, string installScriptPath) {
 
         try {
             if (!System.IO.File.Exists(appPath)) {
@@ -104,7 +106,7 @@ internal class BlenderIntegrator : BaseDCCIntegrator {
             //Delete plugin on mac to avoid errors of loading new plugin:
             //Termination Reason: Namespace CODESIGNING, Code 0x2 
             string installedPluginDir = Environment.GetFolderPath(Environment.SpecialFolder.Personal)
-                + "/Library/Application Support/Blender/2.83/scripts/addons/MeshSyncClientBlender";
+                + $"/Library/Application Support/Blender/{dccToolVersion}/scripts/addons/MeshSyncClientBlender";
             string[] files = System.IO.Directory.GetFiles(installedPluginDir, "*.so");
             if (files.Length > 0) {
                 foreach (string binaryPluginFile in files) {

--- a/MeshSync~/Packages/manifest.json
+++ b/MeshSync~/Packages/manifest.json
@@ -4,7 +4,7 @@
     "com.unity.collab-proxy": "1.2.16",
     "com.unity.ext.nunit": "1.0.0",
     "com.unity.formats.fbx": "3.1.0-preview.1",
-    "com.unity.ide.rider": "3.0.1",
+    "com.unity.ide.rider": "3.0.2",
     "com.unity.ide.vscode": "1.2.2",
     "com.unity.package-validation-suite": "0.11.0-preview",
     "com.unity.quicksearch": "1.5.2",

--- a/MeshSync~/Packages/packages-lock.json
+++ b/MeshSync~/Packages/packages-lock.json
@@ -47,7 +47,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.ide.rider": {
-      "version": "3.0.1",
+      "version": "3.0.2",
       "depth": 0,
       "source": "registry",
       "dependencies": {


### PR DESCRIPTION
Blender plugin installation sometimes failed with the following reason:

`Termination Reason: Namespace CODESIGNING, Code 0x2`