### PR TITLE
fix: error when copying DCC Plugins after installing MeshSyncDCCPlugins 

### DIFF
--- a/Editor/Scripts/DCCIntegration/DCCPluginDownloader.cs
+++ b/Editor/Scripts/DCCIntegration/DCCPluginDownloader.cs
@@ -80,22 +80,34 @@ internal class DCCPluginDownloader  {
     void CopyDCCPluginsFromPackage(string version) {
 
         foreach (string dccPlatformName in m_dccPlatformNames) {
-            const string DCC_PLUGIN_SRC_FOLDER = "Packages/" + MESHSYNC_DCC_PLUGIN_PACKAGE + "/Editor/Plugins~";
 
+            //Check several folders
+            string[] folders = {
+                $"Packages/{MESHSYNC_DCC_PLUGIN_PACKAGE}/Editor/Plugins~",
+                $"Library/PackageCache/{MESHSYNC_DCC_PLUGIN_PACKAGE}@{version}/Editor/Plugins~",                
+            };
+            
             string[] zipFileNames = {
                 "UnityMeshSync_" + version + "_" + dccPlatformName,
                 "UnityMeshSync_" + dccPlatformName,
             };
 
             string srcZipFilePath = null;
-            foreach (string zipFileName in zipFileNames) {
-                string path = Path.GetFullPath(Path.Combine(DCC_PLUGIN_SRC_FOLDER, zipFileName));
-                if (!File.Exists(path)) {
-                    continue;
+
+            foreach (string folder in folders) {
+                foreach (string zipFileName in zipFileNames) {
+                    string path = Path.GetFullPath(Path.Combine(folder, zipFileName));
+                    Debug.Log("Checking path: " + path);
+                    if (!File.Exists(path)) {
+                        continue;
+                    }
+
+                    srcZipFilePath = path;
+                    break;
                 }
 
-                srcZipFilePath = path;
-                break;
+                if (!string.IsNullOrEmpty(srcZipFilePath))
+                    break;
             }
 
             if (string.IsNullOrEmpty(srcZipFilePath)) {

--- a/Editor/Scripts/DCCIntegration/DCCPluginDownloader.cs
+++ b/Editor/Scripts/DCCIntegration/DCCPluginDownloader.cs
@@ -97,7 +97,6 @@ internal class DCCPluginDownloader  {
             foreach (string folder in folders) {
                 foreach (string zipFileName in zipFileNames) {
                     string path = Path.GetFullPath(Path.Combine(folder, zipFileName));
-                    Debug.Log("Checking path: " + path);
                     if (!File.Exists(path)) {
                         continue;
                     }

--- a/MeshSync~/ProjectSettings/ProjectVersion.txt
+++ b/MeshSync~/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2019.4.18f1
-m_EditorVersionWithRevision: 2019.4.18f1 (3310a4d4f880)
+m_EditorVersion: 2019.4.19f1
+m_EditorVersionWithRevision: 2019.4.19f1 (ca5b14067cec)


### PR DESCRIPTION
This bug happens after installing MeshSyncDCCPlugins package for the first time