### PR TITLE
refactor-plugin: remove noncopyable.

### DIFF
--- a/Plugin~/Src/MeshUtils/Include/MeshUtils/muMisc.h
+++ b/Plugin~/Src/MeshUtils/Include/MeshUtils/muMisc.h
@@ -40,16 +40,6 @@ void InitializeSymbols(const char *path = nullptr);
 void* FindSymbolByName(const char *name);
 void* FindSymbolByName(const char *name, const char *module_name);
 
-
-struct noncopyable
-{
-    noncopyable() {}
-    noncopyable(noncopyable&&) {}
-    noncopyable(const noncopyable&) = delete;
-    noncopyable& operator=(const noncopyable&) = delete;
-};
-
-
 enum class MemoryFlags
 {
     ExecuteRead,


### PR DESCRIPTION
Using noncopyable will require a class to have multiple parents, if that class already has an original parent, and our policy is to avoid using multiple inheritance.

Therefore, this class won't be used.