### PR TITLE
fix: compare the major and minor versions of the plugin with those of the package

### DIFF
--- a/Tests/Editor/PluginTest.cs
+++ b/Tests/Editor/PluginTest.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections;
 using NUnit.Framework;
+using Unity.FilmInternalUtilities.Editor;
 using UnityEngine.TestTools;
 using UnityEditor.PackageManager;
 using UnityEditor.PackageManager.Requests;
@@ -14,12 +15,22 @@ public class PluginTest {
         while (!list.IsCompleted)
             yield return null;
 
+        bool parsed = PackageVersion.TryParse(Lib.GetPluginVersion(), out PackageVersion libVersion);
+        Assert.IsTrue(parsed);
+        
+        
         foreach (PackageInfo packageInfo in list.Result) {
             if (packageInfo.name != MeshSyncConstants.PACKAGE_NAME)
                 continue;
+
+            parsed = PackageVersion.TryParse(packageInfo.version, out PackageVersion packageVersion);
+            Assert.IsTrue(parsed);
             
             
-            Assert.AreEqual(Lib.GetPluginVersion(),packageInfo.version);
+            //Based on our rule to increase the major/minor version whenever we change any plugin code,
+            //it's ok for the patch version to be different.
+            Assert.AreEqual(libVersion.Major, packageVersion.Major);           
+            Assert.AreEqual(libVersion.Minor, packageVersion.Minor);            
             yield break;
         }
         


### PR DESCRIPTION
This rule makes sense based on our rule to increase the major/minor version whenever we change any plugin code.