### PR TITLE
revert: use parent path when trying to find/create a GameObject (397)

### DIFF
--- a/Runtime/Scripts/MeshSyncPlayer.cs
+++ b/Runtime/Scripts/MeshSyncPlayer.cs
@@ -8,7 +8,6 @@ using UnityEngine.Animations;
 using Unity.Collections;
 using UnityEngine.Assertions;
 using System.IO;
-using JetBrains.Annotations;
 
 #if UNITY_EDITOR
 using UnityEditor;
@@ -1276,24 +1275,15 @@ internal abstract class MeshSyncPlayer : MonoBehaviour, ISerializationCallbackRe
                 return null;
         } else  {
             if (m_clientObjects.TryGetValue(path, out rec)) {
-                if (rec.go == null) {
+                if (rec.go == null)
+                {
                     m_clientObjects.Remove(path);
                     rec = null;
                 }
             }
             
             if (rec == null) {
-
-                //Optimize: try using registered parent to find/create 
-                Transform parentTrans = GetRegisteredParentTransform(path, out string parentPath);
-                if (null != parentTrans) {
-                    string childPath = path.Substring(parentPath.Length+1);
-                    trans = GameObjectUtility.FindOrCreateByPath(parentTrans, childPath, false);                                                
-                } else {
-                    trans = GameObjectUtility.FindOrCreateByPath(m_rootObject, path, false);                    
-                }
-
-                Assert.IsNotNull(trans);                
+                trans = GameObjectUtility.FindOrCreateByPath(m_rootObject, path, false);
                 rec = new EntityRecord {
                     go = trans.gameObject,
                     trans = trans,
@@ -1797,25 +1787,6 @@ internal abstract class MeshSyncPlayer : MonoBehaviour, ISerializationCallbackRe
         }
         return ret;
     }
-
-    //Get the parent transform from m_clientObjects
-    [CanBeNull]
-    Transform GetRegisteredParentTransform(string path, out string retParentPath) {
-        retParentPath = null;
-        string parentPath = GameObjectUtility.GetParentPath(path);
-        if (!string.IsNullOrEmpty(parentPath)) {
-            if (m_clientObjects.TryGetValue(parentPath, out EntityRecord parentRec)) {
-                if (null != parentRec.go) {
-                    retParentPath = parentPath;
-                    return parentRec.trans;
-                }
-            }
-        }
-
-        return null;
-
-    }
-    
     #endregion
 
     #region Tools

--- a/Runtime/Scripts/Utilities/GameObjectUtility.cs
+++ b/Runtime/Scripts/Utilities/GameObjectUtility.cs
@@ -60,8 +60,8 @@ internal static class GameObjectUtility {
     }
        
     //[TODO-sin: 2021-9-6] Move to FIU
-    // 1. Name Delimiter is '/'
-    // 2. Empty names are ignored
+    // 2. Name Delimiter is '/'
+    // 3. Empty names are ignored
     internal static Transform FindOrCreateByPath(Transform parent, string path, bool worldPositionStays = true) {
         string[] names = path.Split('/');
         if (names.Length <= 0)
@@ -94,28 +94,7 @@ internal static class GameObjectUtility {
 
         return t;        
     }
-
-//----------------------------------------------------------------------------------------------------------------------    
     
-    //[TODO-sin: 2021-9-6] Move to FIU
-    // 1. delimiter is '/'
-    // 2. may return null
-    [CanBeNull]
-    internal static string GetParentPath(string path) {
-        if (string.IsNullOrEmpty(path))
-            return null;
-        
-        int lastDelimiterPos = path.LastIndexOf('/');
-        if (lastDelimiterPos == -1)
-            return null;
-
-        //Check if the path doesn't contain any parent
-        int firstDelimiterPos = path.IndexOf('/');
-        if (firstDelimiterPos == lastDelimiterPos)
-            return null;
-        
-        return path.Substring(0, lastDelimiterPos);
-    }
     
 }
 

--- a/Tests/Runtime/GameObjectUtilityTest.cs
+++ b/Tests/Runtime/GameObjectUtilityTest.cs
@@ -76,19 +76,6 @@ internal class GameObjectUtilityTest {
         Assert.AreEqual(d,  created_d);        
     }
     
-//----------------------------------------------------------------------------------------------------------------------    
-
-    [Test]
-    public void CheckParentPaths() {
-        
-        Assert.AreEqual(null, GameObjectUtility.GetParentPath(null));
-        Assert.AreEqual(null, GameObjectUtility.GetParentPath("/"));
-        Assert.AreEqual(null, GameObjectUtility.GetParentPath("Root"));
-        Assert.AreEqual(null, GameObjectUtility.GetParentPath("/Root"));
-
-        Assert.AreEqual("/Root", GameObjectUtility.GetParentPath("/Root/Child"));
-        Assert.AreEqual("/Root/Child", GameObjectUtility.GetParentPath("/Root/Child/GrandChild"));
-    }
     
 //----------------------------------------------------------------------------------------------------------------------    
     


### PR DESCRIPTION
This reverts commit ef9fed060293abc2055ac21ea7152fff82d66c0d.

No performance improvement is observed
