### PR TITLE
chore: fix the script to sync package info 

### DIFF
--- a/Scripts~/sync_package_info.sh
+++ b/Scripts~/sync_package_info.sh
@@ -7,8 +7,8 @@ allProjects=(
 packageName="com.unity.meshsync"
 
 for project in ${allProjects[@]}; do    
-    cp package.json "${project}\\Packages\\${packageName}"
-    cp CHANGELOG.md "${project}\\Packages\\${packageName}"    
+    cp package.json "${project}/Packages/${packageName}"
+    cp CHANGELOG.md "${project}/Packages/${packageName}"    
 done
 
 


### PR DESCRIPTION
didn't work on mac/linux