### PR TITLE
feat: add support to detect and install plugin for Blender 3.2

### DIFF
--- a/Editor/Scripts/MeshSyncEditorConstants.cs
+++ b/Editor/Scripts/MeshSyncEditorConstants.cs
@@ -53,6 +53,7 @@ internal static class MeshSyncEditorConstants {
         { "Blender 2.93", new DCCToolInfo(DCCToolType.BLENDER, "2.93" ) },
         { "Blender 3.0", new DCCToolInfo(DCCToolType.BLENDER, "3.0" ) },
         { "Blender 3.1", new DCCToolInfo(DCCToolType.BLENDER, "3.1" ) },
+        { "Blender 3.2", new DCCToolInfo(DCCToolType.BLENDER, "3.2" ) },
 #elif UNITY_EDITOR_OSX
         { "Blender/2.83", new DCCToolInfo(DCCToolType.BLENDER, "2.83" ) }, 
         { "Blender/2.90", new DCCToolInfo(DCCToolType.BLENDER, "2.90" ) }, 
@@ -61,6 +62,7 @@ internal static class MeshSyncEditorConstants {
         { "Blender/2.93", new DCCToolInfo(DCCToolType.BLENDER, "2.93" ) }, 
         { "Blender/3.0", new DCCToolInfo(DCCToolType.BLENDER, "3.0" ) }, 
         { "Blender/3.1", new DCCToolInfo(DCCToolType.BLENDER, "3.1" ) }, 
+        { "Blender/3.2", new DCCToolInfo(DCCToolType.BLENDER, "3.2" ) }, 
         { "Blender.app", new DCCToolInfo(DCCToolType.BLENDER, null ) },  //app directly
 #elif UNITY_EDITOR_LINUX
         { "blender-2.83.0-linux64", new DCCToolInfo(DCCToolType.BLENDER, "2.83" ) },        
@@ -86,8 +88,19 @@ internal static class MeshSyncEditorConstants {
         { "blender-2.92.0-linux64", new DCCToolInfo(DCCToolType.BLENDER, "2.92" ) },
         { "blender-2.93.0-stable+blender-v293-release.84da05a8b806-linux.x86_64-release", new DCCToolInfo(DCCToolType.BLENDER, "2.93" ) },
         { "blender-2.93.1-linux-x64", new DCCToolInfo(DCCToolType.BLENDER, "2.93" ) },
+        { "blender-2.93.2-linux-x64", new DCCToolInfo(DCCToolType.BLENDER, "2.93" ) },
+        { "blender-2.93.3-linux-x64", new DCCToolInfo(DCCToolType.BLENDER, "2.93" ) },
+        { "blender-2.93.4-linux-x64", new DCCToolInfo(DCCToolType.BLENDER, "2.93" ) },
+        { "blender-2.93.5-linux-x64", new DCCToolInfo(DCCToolType.BLENDER, "2.93" ) },
+        { "blender-2.93.6-linux-x64", new DCCToolInfo(DCCToolType.BLENDER, "2.93" ) },
+        { "blender-2.93.7-linux-x64", new DCCToolInfo(DCCToolType.BLENDER, "2.93" ) },
+        { "blender-2.93.8-linux-x64", new DCCToolInfo(DCCToolType.BLENDER, "2.93" ) },
+        { "blender-2.93.9-linux-x64", new DCCToolInfo(DCCToolType.BLENDER, "2.93" ) },
         { "blender-3.0.1-linux-x64", new DCCToolInfo(DCCToolType.BLENDER, "3.0" ) },
         { "blender-3.1.0-linux-x64", new DCCToolInfo(DCCToolType.BLENDER, "3.1" ) },
+        { "blender-3.1.1-linux-x64", new DCCToolInfo(DCCToolType.BLENDER, "3.1" ) },
+        { "blender-3.1.2-linux-x64", new DCCToolInfo(DCCToolType.BLENDER, "3.1" ) },
+        { "blender-3.2.0-linux-x64", new DCCToolInfo(DCCToolType.BLENDER, "3.2" ) },
 #endif        
         
     };


### PR DESCRIPTION
This assumes that the plugin already exists in MeshSyncDCCPlugin

Others:
* detect more 2.93 and 3.1 versions