### PR TITLE
fix: server hanging on exit, after updating package version

### DIFF
--- a/Editor/Scripts/Server/EditorServer.cs
+++ b/Editor/Scripts/Server/EditorServer.cs
@@ -46,8 +46,14 @@ internal static class EditorServer {
         // Defer the Initialisation to the first update call
         EditorApplication.update -= Init;
         EditorApplication.update += Init;
+        
+        EditorApplication.quitting -= OnQuit;
+        EditorApplication.quitting += OnQuit;
     }
-    
+
+    private static void OnQuit() {
+        m_server.Abort();
+    }
 
     /// <summary>
     /// Apply settings from CLI arguments or use Editor Server Settings.

--- a/Plugin~/Src/MeshSync/Include/MeshSync/msServer.h
+++ b/Plugin~/Src/MeshSync/Include/MeshSync/msServer.h
@@ -45,6 +45,7 @@ public:
 
     bool start();
     void stop();
+    void abort();
     void clear();
     ServerSettings& getSettings();
 

--- a/Plugin~/Src/MeshSync/msServer.cpp
+++ b/Plugin~/Src/MeshSync/msServer.cpp
@@ -58,6 +58,12 @@ void Server::stop()
     m_server.reset();
 }
 
+void Server::abort() {
+    if (m_server) {
+        m_server->stopAll(true);
+    }
+}
+
 void Server::clear()
 {
     lock_t lock(m_message_mutex);

--- a/Plugin~/Src/mscore/msServerAPI.cpp
+++ b/Plugin~/Src/mscore/msServerAPI.cpp
@@ -154,6 +154,14 @@ msAPI void  msServerStop(ms::Server *server)
     }
 }
 
+msAPI void  msServerAbort(ms::Server* server)
+{
+    // stop server and shut down client connections
+    if (server) {
+        server->abort();
+    }
+}
+
 msAPI uint32_t msServerGetSplitUnit(ms::Server *server)
 {
     return server ? server->getSettings().import_settings.mesh_split_unit : 0;

--- a/Runtime/Scripts/MeshSyncServer.cs
+++ b/Runtime/Scripts/MeshSyncServer.cs
@@ -156,6 +156,10 @@ public partial class MeshSyncServer : BaseMeshSync, IDisposable {
 #if UNITY_EDITOR
         EditorApplication.update -= PollServerEvents;
         EditorApplication.update += PollServerEvents;
+        
+        EditorApplication.quitting -= OnEditorQuit;
+        EditorApplication.quitting += OnEditorQuit;
+        
 #endif
         if (m_config.Logging)
             Debug.Log("[MeshSync] Server started (port: " + m_serverSettings.port + ")");
@@ -165,7 +169,13 @@ public partial class MeshSyncServer : BaseMeshSync, IDisposable {
 #endif //UNITY_STANDALONE || UNITY_EDITOR
     }
 
-        //----------------------------------------------------------------------------------------------------------------------        
+    private void OnEditorQuit() {
+        if (m_server) {
+            m_server.Abort();
+        }
+    }
+
+    //----------------------------------------------------------------------------------------------------------------------        
 
     internal void StopServer()
     {

--- a/Runtime/Scripts/msNetworkAPI.cs
+++ b/Runtime/Scripts/msNetworkAPI.cs
@@ -57,6 +57,9 @@ internal struct Server {
 
     [DllImport(Lib.name)]
     static extern void msServerStop(IntPtr self);
+    
+    [DllImport(Lib.name)]
+    static extern void msServerAbort(IntPtr self);
 
     [DllImport(Lib.name)]
     static extern void msServerSetZUpCorrectionMode(IntPtr self, ZUpCorrectionMode v);
@@ -168,6 +171,10 @@ internal struct Server {
         msServerStop(self);
     }
 
+    public void Abort() {
+        msServerAbort(self);
+    }
+    
     internal ZUpCorrectionMode zUpCorrectionMode {
         set { msServerSetZUpCorrectionMode(self, value); }
     }


### PR DESCRIPTION
**Important**: with this solution the application quits only after 20s on my machine. This has been tested when updating between 0.14.5-preview to 0.15.1-preview. I also created an artificial new version 0.15.5 and when updating between 0.15.1-preview and 0.15.5, quitting is instant.

The stop function in our server does not actually stop the server, but rather resets the unique pointer to the server. 
To stop the server when quitting the editor, I have subscribed to the EditorApplication.quitting event where we can invoke Server.Abort() which will stop the server and abort all current requests. 

More info here on HttpServer::stopAll https://github.com/pocoproject/poco/blob/5c3f827c8639a996dd0d27a77f48d343ed6fe524/Net/include/Poco/Net/HTTPServer.h