### PR TITLE
fix: handle zero keys when comparing two curves

### DIFF
--- a/Runtime/Scripts/SceneCache/SceneCachePlayableAsset.cs
+++ b/Runtime/Scripts/SceneCache/SceneCachePlayableAsset.cs
@@ -238,9 +238,14 @@ internal class SceneCachePlayableAsset : BaseExtendedClipPlayableAsset<SceneCach
         Keyframe[] xKeys = x.keys;
         Keyframe[] yKeys = y.keys;
 
-        if (xKeys.Length != yKeys.Length)
+        int numKeys0 = xKeys.Length; 
+
+        if (numKeys0 != yKeys.Length)
             return false;
 
+        if (0 == numKeys0)
+            return true;
+        
         HashSet<int> framesToCheck = new HashSet<int>() {
             0, 
             xKeys.Length - 1


### PR DESCRIPTION
(cherry picked from commit 067de9f9b78869d3d7530db83e050194543819fc)