### PR TITLE
change: output logs of the Editor Server 

### DIFF
--- a/Editor/Scripts/Server/EditorServer.cs
+++ b/Editor/Scripts/Server/EditorServer.cs
@@ -1,5 +1,6 @@
 using System;
-using System.Linq;
+using System.IO;
+using System.Text;
 using Unity.FilmInternalUtilities.Editor;
 using UnityEditor;
 using UnityEngine;
@@ -18,9 +19,23 @@ internal static class EditorServer {
     private const string CLI_ARGUMENT_PORT   = "PORT";
     private const string CLI_ARGUMENT_ACTIVE = "SERVER_ACTIVE";
     
+    private static void UpdateLog() {
+        var appRoot = AssetEditorUtility.GetApplicationRootPath();
+        var path = Path.Combine(appRoot, "Assets", "ProjectSettings", "MeshSyncEditorServerLog.txt");
+        
+        using (var stream = File.Create(path)) {
+            var    log   = $"active:{Active}\nport:{Port}";
+            byte[] bytes = new UTF8Encoding(true).GetBytes(log);
+            stream.Write(bytes, 0, bytes.Length);
+        }
+    }
+    
     internal static bool Active {
         get { return SessionState.GetBool(ACTIVE_KEY, false);}
-        set {SessionState.SetBool(ACTIVE_KEY, value);}
+        set {
+            SessionState.SetBool(ACTIVE_KEY, value);
+            UpdateLog();
+        }
     }
 
     private static bool ActivePrev {
@@ -30,7 +45,10 @@ internal static class EditorServer {
     
     internal static ushort Port {
         get { return (ushort)SessionState.GetInt(PORT_KEY, 8081); }
-        set{ SessionState.SetInt(PORT_KEY, value);}
+        set {
+            SessionState.SetInt(PORT_KEY, value);
+            UpdateLog();
+        }
     }
 
     private static bool AppliedInitialSettings {


### PR DESCRIPTION
Creating a small log for the server. This is helpful for the clients to pick the actual port number being used and also the active status of the server, for better autoconfig