### PR TITLE
fix: keep currentSessionId when switching PlayMode

### DIFF
--- a/Runtime/Scripts/BaseMeshSync.cs
+++ b/Runtime/Scripts/BaseMeshSync.cs
@@ -216,7 +216,8 @@ public struct MeshSyncSessionStartAnalyticsData {
 
         #region Properties
         
-        private int  currentSessionId                 = -1;
+        [SerializeField] private int  currentSessionId = -1;
+        
         private bool forceDeleteChildrenInNextSession = false;
 
         private protected string GetServerDocRootPath() { return Application.streamingAssetsPath + "/MeshSyncServerRoot"; }


### PR DESCRIPTION
Set `currentSessionId` as a `SerializableField` to keep it in memory when switching from EditMode to PlayMode.