### PR TITLE
fix: copy the scale/visibility of instances based on the parent/original respectively

### DIFF
--- a/Runtime/Scripts/BaseMeshSync.cs
+++ b/Runtime/Scripts/BaseMeshSync.cs
@@ -2200,26 +2200,25 @@ public struct MeshSyncSessionStartAnalyticsData {
 
         private static void SetInstanceTransform(GameObject instancedCopy, GameObject parent, Matrix4x4 mat) {
             Transform objTransform = instancedCopy.transform;
-            
-            var converted = parent.transform.localToWorldMatrix * mat;
 
             objTransform.localScale = mat.lossyScale;
-            objTransform.position   = converted.MultiplyPoint(Vector3.zero);
+            objTransform.localPosition   = mat.MultiplyPoint(Vector3.zero);
 
             // Calculate rotation here to avoid gimbal lock issue:
             Vector3 forward;
-            forward.x = converted.m02;
-            forward.y = converted.m12;
-            forward.z = converted.m22;
+            forward.x = mat.m02;
+            forward.y = mat.m12;
+            forward.z = mat.m22;
 
             Vector3 upwards;
-            upwards.x = converted.m01;
-            upwards.y = converted.m11;
-            upwards.z = converted.m21;
+            upwards.x = mat.m01;
+            upwards.y = mat.m11;
+            upwards.z = mat.m21;
 
-            objTransform.rotation = Quaternion.LookRotation(forward, upwards);
+            objTransform.localRotation = Quaternion.LookRotation(forward, upwards);
 
 #if DEBUG
+            var converted   = parent.transform.localToWorldMatrix * mat;
             var localMatrix = objTransform.localToWorldMatrix;
             for (int x = 0; x < 3; x++) {
                 for (int y = 0; y < 3; y++) {


### PR DESCRIPTION
The copy instances use the parent scale as a local scale. So for example, if the parent scale is 4, the copy scale will be 16. This is because we assign the lossy scale of the matrix that has the parent matrix as the local scale matrix.

Additionally, when creating copied instances and we have the visibility synch enabled, we assign the visibility of the copies based on the visibility of the original. This is not accurate as in Blender, only the parent can control the visibility of the instances, not the referenced objects. 
 