### PR TITLE
fix: Blender Uninstall script

### DIFF
--- a/Editor/Scripts/DCCIntegration/Integrators/BlenderIntegrator.cs
+++ b/Editor/Scripts/DCCIntegration/Integrators/BlenderIntegrator.cs
@@ -114,7 +114,7 @@ internal class BlenderIntegrator : BaseDCCIntegrator {
             //Try to uninstall first. The uninstallation may have exceptions/error messages, but they can be ignored
             System.Diagnostics.Process process = DiagnosticsUtility.StartProcess(
                 appPath,
-                $"-b -P {uninstallScriptPath}",
+                $"-b -P \"{uninstallScriptPath}\"",
                 /*useShellExecute=*/ false, /*redirectStandardError=*/ true
             );
             process.WaitForExit();


### PR DESCRIPTION
When the script path has spaces, the script would not be invoked. Applied double quotes around the path to ensure it works on all paths.