### PR TITLE
refactor: abstract material property data to allow custom occlusion strength value 0.25

### DIFF
--- a/Runtime/Scripts/BaseMeshSync.cs
+++ b/Runtime/Scripts/BaseMeshSync.cs
@@ -1116,14 +1116,26 @@ public abstract partial class BaseMeshSync : MonoBehaviour, IObservable<MeshSync
 
         // Put all properties in a list so we can look them up more easily:
         int                                   numProps           = src.numProperties;
-        Dictionary<int, MaterialPropertyData> materialProperties = new Dictionary<int, MaterialPropertyData>(numProps);
+        Dictionary<int, IMaterialPropertyData> materialProperties = new Dictionary<int, IMaterialPropertyData>(numProps);
 
         for (int pi = 0; pi < numProps; ++pi) {
-            MaterialPropertyData prop = src.GetProperty(pi);
+            IMaterialPropertyData prop = src.GetProperty(pi);
             materialProperties.Add(prop.nameID, prop);
         }
+        
+        // Change AO slider value to 0.25
+        CustomMaterialPropertyData aoStrength = new CustomMaterialPropertyData
+        {
+            floatValue = 0.25f,
+            arrayLength = 1,
+            type = IMaterialPropertyData.Type.Float,
+            nameID = MeshSyncConstants._OcclusionStrength
+        };
+        materialProperties.Add(aoStrength.nameID, aoStrength);
+        
+        
 
-        foreach (KeyValuePair<int, MaterialPropertyData> prop in materialProperties)
+        foreach (KeyValuePair<int, IMaterialPropertyData> prop in materialProperties)
             ApplyMaterialProperty(destMat, textureHolders, prop.Value, prop.Key, materialProperties, src.shader);
 
         MapsBaker.BakeMaps(destMat, textureHolders, materialProperties);
@@ -1133,10 +1145,10 @@ public abstract partial class BaseMeshSync : MonoBehaviour, IObservable<MeshSync
     }
 
     private static bool HandleKeywords(Material destMat, List<TextureHolder> textureHolders,
-        MaterialPropertyData prop, string keyword) {
+        IMaterialPropertyData prop, string keyword) {
         // If the texture exists, enable its keyword, otherwise disable it:
-        if (prop.type == MaterialPropertyData.Type.Texture) {
-            MaterialPropertyData.TextureRecord rec = prop.textureValue;
+        if (prop.type == IMaterialPropertyData.Type.Texture) {
+            IMaterialPropertyData.TextureRecord rec = prop.textureValue;
             Texture2D                          tex = FindTexture(rec.id, textureHolders);
 
             if (tex != null) {
@@ -1162,16 +1174,16 @@ public abstract partial class BaseMeshSync : MonoBehaviour, IObservable<MeshSync
 
     private void ApplyMaterialProperty(Material destMat,
         List<TextureHolder> textureHolders,
-        MaterialPropertyData prop,
+        IMaterialPropertyData prop,
         int propNameID,
-        Dictionary<int, MaterialPropertyData> materialProperties,
+        Dictionary<int, IMaterialPropertyData> materialProperties,
         string shaderName) {
         // Shaders use different names to refer to the same maps, this map contains those synonyms so we can apply them to every shader easily:
         if (synonymMap.TryGetValue(propNameID, out int[] synonyms))
             foreach (int synonym in synonyms)
                 ApplyMaterialProperty(destMat, textureHolders, prop, synonym, materialProperties, shaderName);
 
-        MaterialPropertyData.Type propType = prop.type;
+        IMaterialPropertyData.Type propType = prop.type;
         if (!destMat.HasProperty(propNameID))
             return;
 
@@ -1271,29 +1283,29 @@ public abstract partial class BaseMeshSync : MonoBehaviour, IObservable<MeshSync
 
         int len = prop.arrayLength;
         switch (propType) {
-            case MaterialPropertyData.Type.Int:
+            case IMaterialPropertyData.Type.Int:
                 destMat.SetInt(propNameID, prop.intValue);
                 break;
-            case MaterialPropertyData.Type.Float:
+            case IMaterialPropertyData.Type.Float:
                 if (len == 1)
                     destMat.SetFloat(propNameID, prop.floatValue);
                 else
                     destMat.SetFloatArray(propNameID, prop.floatArray);
                 break;
-            case MaterialPropertyData.Type.Vector:
+            case IMaterialPropertyData.Type.Vector:
                 if (len == 1)
                     destMat.SetVector(propNameID, prop.vectorValue);
                 else
                     destMat.SetVectorArray(propNameID, prop.vectorArray);
                 break;
-            case MaterialPropertyData.Type.Matrix:
+            case IMaterialPropertyData.Type.Matrix:
                 if (len == 1)
                     destMat.SetMatrix(propNameID, prop.matrixValue);
                 else
                     destMat.SetMatrixArray(propNameID, prop.matrixArray);
                 break;
-            case MaterialPropertyData.Type.Texture: {
-                MaterialPropertyData.TextureRecord rec = prop.textureValue;
+            case IMaterialPropertyData.Type.Texture: {
+                IMaterialPropertyData.TextureRecord rec = prop.textureValue;
                 Texture2D                          tex = FindTexture(rec.id, textureHolders);
                 // Allow setting of null textures to clear them:
                 destMat.SetTextureAndReleaseExistingRenderTextures(propNameID, tex);
@@ -1303,7 +1315,7 @@ public abstract partial class BaseMeshSync : MonoBehaviour, IObservable<MeshSync
                 }
             }
                 break;
-            case MaterialPropertyData.Type.String:
+            case IMaterialPropertyData.Type.String:
                 // Not used at the moment but would be: prop.stringValue;
                 break;
             default: break;

--- a/Runtime/Scripts/BaseMeshSync.cs
+++ b/Runtime/Scripts/BaseMeshSync.cs
@@ -1230,11 +1230,11 @@ public abstract partial class BaseMeshSync : MonoBehaviour, IObservable<MeshSync
         else if (propNameID == MeshSyncConstants._EmissiveColorMap) {
             Color baseEmissionColor = Color.white;
 
-            if (materialProperties.TryGetValue(MeshSyncConstants._EmissionColor, out MaterialPropertyData emissionColorProp))
+            if (materialProperties.TryGetValue(MeshSyncConstants._EmissionColor, out IMaterialPropertyData emissionColorProp))
                 baseEmissionColor = emissionColorProp.vectorValue;
 
             float emissionStrength = 0;
-            if (materialProperties.TryGetValue(MeshSyncConstants._EmissionStrength, out MaterialPropertyData emissionStrengthProp))
+            if (materialProperties.TryGetValue(MeshSyncConstants._EmissionStrength, out IMaterialPropertyData emissionStrengthProp))
                 emissionStrength = emissionStrengthProp.floatValue;
 
             destMat.SetFloat(MeshSyncConstants._UseEmissiveIntensity, 1);
@@ -1244,8 +1244,8 @@ public abstract partial class BaseMeshSync : MonoBehaviour, IObservable<MeshSync
             destMat.SetColor(MeshSyncConstants._EmissiveColor, baseEmissionColor * emissionStrength);
         }
         else if (propNameID == MeshSyncConstants._HeightMap) {
-            if (prop.type == MaterialPropertyData.Type.Texture) {
-                MaterialPropertyData.TextureRecord rec = prop.textureValue;
+            if (prop.type == IMaterialPropertyData.Type.Texture) {
+                IMaterialPropertyData.TextureRecord rec = prop.textureValue;
                 Texture2D                          tex = FindTexture(rec.id, textureHolders);
                 if (tex != null) {
                     destMat.EnableKeyword(MeshSyncConstants._HEIGHTMAP);
@@ -1259,7 +1259,7 @@ public abstract partial class BaseMeshSync : MonoBehaviour, IObservable<MeshSync
                     // Fallback value in case the node setup in blender does not specify the height scale.
                     // Normally this is not used because the value comes from the displacement node:
                     float scale = 10;
-                    if (materialProperties.TryGetValue(MeshSyncConstants._Parallax, out MaterialPropertyData heightScaleProp))
+                    if (materialProperties.TryGetValue(MeshSyncConstants._Parallax, out IMaterialPropertyData heightScaleProp))
                         scale = heightScaleProp.floatValue;
 
                     destMat.SetFloat(MeshSyncConstants._HeightMin, -scale);

--- a/Runtime/Scripts/CustomMaterialPropertyData.cs
+++ b/Runtime/Scripts/CustomMaterialPropertyData.cs
@@ -1,0 +1,20 @@
+﻿using UnityEngine;
+
+namespace Unity.MeshSync
+{
+    internal class CustomMaterialPropertyData : IMaterialPropertyData
+    {
+        public string name { get; set; }
+        public int nameID { get; set; }
+        public IMaterialPropertyData.Type type { get; set; }
+        public int intValue { get; set; }
+        public float floatValue { get; set; }
+        public Vector4 vectorValue { get; set; }
+        public Matrix4x4 matrixValue { get; set; }
+        public IMaterialPropertyData.TextureRecord textureValue { get; set; }
+        public int arrayLength { get; set; }
+        public float[] floatArray { get; set; }
+        public Vector4[] vectorArray { get; set; }
+        public Matrix4x4[] matrixArray { get; set; }
+    }
+}

--- a/Runtime/Scripts/CustomMaterialPropertyData.cs.meta
+++ b/Runtime/Scripts/CustomMaterialPropertyData.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: a364c38b633148358767683a0f977190
+timeCreated: 1674232750

--- a/Runtime/Scripts/IMaterialPropertyData.cs
+++ b/Runtime/Scripts/IMaterialPropertyData.cs
@@ -1,0 +1,36 @@
+﻿using UnityEngine;
+
+namespace Unity.MeshSync
+{
+    internal interface IMaterialPropertyData
+    {
+        public enum Type {
+            Unknown,
+            Int,
+            Float,
+            Vector,
+            Matrix,
+            Texture,
+            String
+        }
+        public struct TextureRecord {
+            public int     id;
+            public bool    hasScaleOffset;
+            public Vector2 scale, offset;
+        }
+        
+        string name { get; }
+        int nameID { get; }
+        Type type { get; }
+        int intValue { get; }
+        float floatValue { get; }
+        Vector4 vectorValue { get; }
+        Matrix4x4 matrixValue { get; }
+        TextureRecord textureValue { get; }
+        int arrayLength { get; }
+        float[] floatArray { get; }
+        Vector4[] vectorArray { get; }
+        Matrix4x4[] matrixArray { get; }
+        string ToString();
+    }
+}

--- a/Runtime/Scripts/IMaterialPropertyData.cs.meta
+++ b/Runtime/Scripts/IMaterialPropertyData.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 239639f147a7427c8b02dd28634c23a4
+timeCreated: 1674232677

--- a/Runtime/Scripts/MeshSyncConstants.cs
+++ b/Runtime/Scripts/MeshSyncConstants.cs
@@ -60,6 +60,7 @@ internal static class MeshSyncConstants {
     internal static readonly int _CoatMaskMap              = Shader.PropertyToID("_CoatMaskMap");
     internal static readonly int _CoatMask                 = Shader.PropertyToID("_CoatMask");
     internal static readonly int _OcclusionMap             = Shader.PropertyToID("_OcclusionMap");
+    internal static readonly int _OcclusionStrength        = Shader.PropertyToID("_OcclusionStrength");
 
     #endregion
 

--- a/Runtime/Scripts/msCoreAPI.cs
+++ b/Runtime/Scripts/msCoreAPI.cs
@@ -459,7 +459,8 @@ internal struct TextureData {
 
 #region Material
 
-internal struct MaterialPropertyData {
+internal struct MaterialPropertyData : IMaterialPropertyData
+{
     #region internal
 
     public IntPtr self;
@@ -468,7 +469,7 @@ internal struct MaterialPropertyData {
     private static extern IntPtr msMaterialPropGetName(IntPtr self);
 
     [DllImport(Lib.name)]
-    private static extern Type msMaterialPropGetType(IntPtr self);
+    private static extern IMaterialPropertyData.Type msMaterialPropGetType(IntPtr self);
 
     [DllImport(Lib.name)]
     private static extern int msMaterialPropGetArrayLength(IntPtr self);
@@ -486,7 +487,7 @@ internal struct MaterialPropertyData {
     private static extern void msMaterialPropCopyData(IntPtr self, ref Matrix4x4 dst);
 
     [DllImport(Lib.name)]
-    private static extern void msMaterialPropCopyData(IntPtr self, ref TextureRecord dst);
+    private static extern void msMaterialPropCopyData(IntPtr self, ref IMaterialPropertyData.TextureRecord dst);
 
     [DllImport(Lib.name)]
     private static extern void msMaterialPropCopyData(IntPtr self, float[] dst);
@@ -502,21 +503,7 @@ internal struct MaterialPropertyData {
 
     #endregion
 
-    public enum Type {
-        Unknown,
-        Int,
-        Float,
-        Vector,
-        Matrix,
-        Texture,
-        String
-    }
 
-    public struct TextureRecord {
-        public int     id;
-        public bool    hasScaleOffset;
-        public Vector2 scale, offset;
-    }
 
     public static implicit operator bool(MaterialPropertyData v) {
         return v.self != IntPtr.Zero;
@@ -534,7 +521,7 @@ internal struct MaterialPropertyData {
         get { return  Shader.PropertyToID(name); }
     }
 
-    public Type type {
+    public IMaterialPropertyData.Type type {
         get {
             if (self == IntPtr.Zero) return default;
 
@@ -582,11 +569,11 @@ internal struct MaterialPropertyData {
         }
     }
 
-    public TextureRecord textureValue {
+    public IMaterialPropertyData.TextureRecord textureValue {
         get {
             if (self == IntPtr.Zero) return default;
 
-            TextureRecord ret = default(TextureRecord);
+            IMaterialPropertyData.TextureRecord ret = default(IMaterialPropertyData.TextureRecord);
             msMaterialPropCopyData(self, ref ret);
             return ret;
         }
@@ -782,7 +769,7 @@ internal struct MaterialData {
     internal Color color {
         get {
             MaterialPropertyData p = FindProperty("_Color");
-            if (p && p.type == MaterialPropertyData.Type.Vector)
+            if (p && p.type == IMaterialPropertyData.Type.Vector)
                 return p.vectorValue;
             else
                 return Color.white;

--- a/Runtime/Shaders/MapsBaker.cs
+++ b/Runtime/Shaders/MapsBaker.cs
@@ -103,7 +103,7 @@ internal static class MapsBaker {
 #if AT_USE_HDRP
     private static void BakeMaskMap(Material destMat,
         List<TextureHolder> textureHolders,
-        Dictionary<int, MaterialPropertyData> materialProperties) {
+        Dictionary<int, IMaterialPropertyData> materialProperties) {
         if (!destMat.HasProperty(MeshSyncConstants._MaskMap)) return;
 
         // Mask map:

--- a/Runtime/Shaders/MapsBaker.cs
+++ b/Runtime/Shaders/MapsBaker.cs
@@ -47,12 +47,12 @@ internal static class MapsBaker {
 
     private static bool FindTexture(int nameID,
         List<TextureHolder> textureHolders,
-        Dictionary<int, MaterialPropertyData> materialProperties,
+        Dictionary<int, IMaterialPropertyData> materialProperties,
         int fallbackPropertyNameID,
         float fallbackPropertyValue,
         out Texture2DDisposable disposableTexture) {
-        if (materialProperties.TryGetValue(nameID, out MaterialPropertyData prop)) {
-            MaterialPropertyData.TextureRecord rec = prop.textureValue;
+        if (materialProperties.TryGetValue(nameID, out IMaterialPropertyData prop)) {
+            IMaterialPropertyData.TextureRecord rec = prop.textureValue;
             disposableTexture = new Texture2DDisposable(BaseMeshSync.FindTexture(rec.id, textureHolders), false);
 
             if (disposableTexture.Texture != null) return true;
@@ -61,7 +61,7 @@ internal static class MapsBaker {
         // If there is no such texture, create one with the given fallback value:
 
         float value = fallbackPropertyValue;
-        if (materialProperties.TryGetValue(fallbackPropertyNameID, out MaterialPropertyData fallbackMaterialProperty))
+        if (materialProperties.TryGetValue(fallbackPropertyNameID, out IMaterialPropertyData fallbackMaterialProperty))
             value = fallbackMaterialProperty.floatValue;
 
         const int dim = 8;
@@ -78,7 +78,7 @@ internal static class MapsBaker {
     }
 
     private static void GetSmoothnessOrRoughnessMap(
-        Dictionary<int, MaterialPropertyData> materialProperties,
+        Dictionary<int, IMaterialPropertyData> materialProperties,
         List<TextureHolder> textureHolders,
         out Texture2DDisposable texture,
         out bool usingRoughness,
@@ -155,7 +155,7 @@ internal static class MapsBaker {
 #else
     private static void BakeSmoothness(Material destMat,
         List<TextureHolder> textureHolders,
-        Dictionary<int, MaterialPropertyData> materialProperties) {
+        Dictionary<int, IMaterialPropertyData> materialProperties) {
         if (!destMat.HasProperty(_SmoothnessTextureChannel)) return;
 
         int smoothnessChannel = destMat.GetInt(_SmoothnessTextureChannel);
@@ -235,7 +235,7 @@ internal static class MapsBaker {
 
     public static void BakeMaps(Material destMat,
         List<TextureHolder> textureHolders,
-        Dictionary<int, MaterialPropertyData> materialProperties) {
+        Dictionary<int, IMaterialPropertyData> materialProperties) {
 #if AT_USE_HDRP
         BakeMaskMap(destMat, textureHolders, materialProperties);
 #else


### PR DESCRIPTION
Setting occlusion slider default value to 0.25 instead of 1. Strength of 1 gives very strong results that look like artifacts. 
Before
![image](https://user-images.githubusercontent.com/51912249/213765960-9ec3a6e4-e8de-46eb-b6c2-b68501bec21e.png)
After
![image](https://user-images.githubusercontent.com/51912249/213766213-8fa36000-4e03-4bf5-b0c4-7663be1d77d2.png)

