### PR TITLE
fix: fix for crashes where instantiated objects are not meshes and not part of the scene

### DIFF
--- a/Runtime/Scripts/BaseMeshSync.cs
+++ b/Runtime/Scripts/BaseMeshSync.cs
@@ -674,6 +674,12 @@ public abstract partial class BaseMeshSync : MonoBehaviour, IObservable<MeshSync
             int numMeshes = scene.numInstancedEntities;
             for (int i = 0; i < numMeshes; ++i) {
                 TransformData src = scene.GetInstancedEntity(i);
+                
+                // If an instance entity is not part of the scene, it can only be supported if it is a Mesh
+                //[TODO] Refactor code to support more types
+                if (src.entityType != EntityType.Mesh)
+                    continue;
+                
                 EntityRecord  dst = UpdateInstancedEntity(src);
 
                 if (dst == null) return;


### PR DESCRIPTION
This fixes a hard crash when synching a file, like this one https://download.blender.org/demo/test/classroom.zip
These files have a main scene that references objects from other .blend files. While we support transferring these references, we assume that these objects are meshes and we attempt to extract mesh info from them.

For example,  in the classroom demo, there is a point light that is referenced. We attempt to access mesh data from that point light, which results in unexpected behavior. In my case, it would crash the editor.