### PR TITLE
fix: prevent overwriting materials when OverwriteExportedMaterials is false

### DIFF
--- a/Runtime/Scripts/BaseMeshSync.cs
+++ b/Runtime/Scripts/BaseMeshSync.cs
@@ -1028,7 +1028,6 @@ public abstract partial class BaseMeshSync : MonoBehaviour, IObservable<MeshSync
 #if UNITY_EDITOR
             dst.material = SearchMaterialInEditor(importerSettings.MaterialSearchMode, materialName);
             if (null != dst.material) {
-                dst.ShouldApplyMaterialData = false;
                 isNewMaterial = false;
             }
             else

--- a/Runtime/Scripts/BaseMeshSync.cs
+++ b/Runtime/Scripts/BaseMeshSync.cs
@@ -1029,6 +1029,7 @@ public abstract partial class BaseMeshSync : MonoBehaviour, IObservable<MeshSync
             dst.material = SearchMaterialInEditor(importerSettings.MaterialSearchMode, materialName);
             if (null != dst.material) {
                 dst.ShouldApplyMaterialData = false;
+                isNewMaterial = false;
             }
             else
 #endif

--- a/Runtime/Scripts/BaseMeshSync.cs
+++ b/Runtime/Scripts/BaseMeshSync.cs
@@ -1043,14 +1043,14 @@ public abstract partial class BaseMeshSync : MonoBehaviour, IObservable<MeshSync
         if (dst == null || dst.material == null)
             return;
         
-        dst.ShouldApplyMaterialData = isNewMaterial || importerSettings.OverwriteExportedMaterials;
+        bool shouldApplyMaterialData = isNewMaterial || importerSettings.OverwriteExportedMaterials;
             
         dst.name  = materialName;
         dst.index = src.index;
         dst.color = src.color;
 
         Material destMat = dst.material;
-        if (importerSettings.CreateMaterials && dst.ShouldApplyMaterialData) ApplyMaterialDataToMaterial(src, destMat, m_textureList);
+        if (importerSettings.CreateMaterials && shouldApplyMaterialData) ApplyMaterialDataToMaterial(src, destMat, m_textureList);
 
         if (onUpdateMaterial != null)
             onUpdateMaterial.Invoke(destMat, src);

--- a/Runtime/Scripts/BaseMeshSync.cs
+++ b/Runtime/Scripts/BaseMeshSync.cs
@@ -1014,6 +1014,8 @@ public abstract partial class BaseMeshSync : MonoBehaviour, IObservable<MeshSync
 
         MaterialHolder dst = m_materialList.Find(a => a.id == materialID);
 
+        bool isNewMaterial = dst == null || dst.material == null;
+        
         //if (invalid && creating materials is allowed)
         if ((dst == null || dst.material == null || dst.name != materialName) && importerSettings.CreateMaterials) {
             if (null == dst) {
@@ -1041,9 +1043,8 @@ public abstract partial class BaseMeshSync : MonoBehaviour, IObservable<MeshSync
         if (dst == null || dst.material == null)
             return;
         
-        if (importerSettings.OverwriteExportedMaterials)
-            dst.ShouldApplyMaterialData = true;
-
+        dst.ShouldApplyMaterialData = isNewMaterial || importerSettings.OverwriteExportedMaterials;
+            
         dst.name  = materialName;
         dst.index = src.index;
         dst.color = src.color;

--- a/Runtime/Scripts/PlayerData/MaterialHolder.cs
+++ b/Runtime/Scripts/PlayerData/MaterialHolder.cs
@@ -9,7 +9,5 @@ internal class MaterialHolder {
     public int      index;
     public Color    color = Color.white;
     public Material material;
-
-    public bool ShouldApplyMaterialData = true;
 }
 } //end namespace


### PR DESCRIPTION
Fix for this: https://github.com/unity3d-jp/MeshSync/issues/902
