### PR TITLE
internal:  add a field to skip texture imports

### DIFF
--- a/Runtime/Scripts/BaseMeshSync.cs
+++ b/Runtime/Scripts/BaseMeshSync.cs
@@ -890,7 +890,13 @@ public abstract partial class BaseMeshSync : MonoBehaviour, IObservable<MeshSync
 
     //----------------------------------------------------------------------------------------------------------------------
 
-    private void UpdateTextureAsset(TextureData src) {
+    private void UpdateTextureAsset(TextureData src)
+    {
+        if (!GetConfigV().GetModelImporterSettings().ImportTextures)
+        {
+            return;
+        }
+        
         MakeSureAssetDirectoryExists();
         Texture2D texture = null;
 #if UNITY_EDITOR

--- a/Runtime/Scripts/Settings/Data/ModelImporterSettings.cs
+++ b/Runtime/Scripts/Settings/Data/ModelImporterSettings.cs
@@ -18,6 +18,7 @@ internal class ModelImporterSettings {
     [SerializeField] internal AssetSearchMode MaterialSearchMode         = AssetSearchMode.LOCAL;
     [SerializeField] internal bool            OverwriteExportedMaterials = false;
     [SerializeField] internal Shader          DefaultShader;
+    internal bool ImportTextures = true;
 
 //----------------------------------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
Texture import is slow. This allows scripts to disable texture imports temporarily.