### PR TITLE
[For 0.18.x] change: add an option to use/ignore normals for checksum calculation. 

### DIFF
--- a/Plugin~/Src/MeshSync/Include/MeshSync/SceneGraph/msMesh.h
+++ b/Plugin~/Src/MeshSync/Include/MeshSync/SceneGraph/msMesh.h
@@ -135,7 +135,7 @@ public:
     SharedVector<mu::Weights1>  weights1;
     uint32_t bone_weight_count = 0; // sum of bone_counts
 
-
+    static bool useNormalsForHashing;
 protected:
     Mesh();
     ~Mesh() override;

--- a/Plugin~/Src/MeshSync/SceneGraph/msMesh.cpp
+++ b/Plugin~/Src/MeshSync/SceneGraph/msMesh.cpp
@@ -9,6 +9,8 @@
 
 namespace ms {
 
+bool Mesh::useNormalsForHashing = true;
+
 static_assert(sizeof(MeshDataFlags) == sizeof(uint32_t), "");
 static_assert(sizeof(MeshRefineFlags) == sizeof(uint32_t), "");
 
@@ -510,7 +512,12 @@ uint64_t Mesh::checksumGeom() const
     uint64_t ret = 0;
     ret += refine_settings.checksum();
 #define Body(A) ret += csum(A);
-    EachGeometryAttributeExceptNormals(Body);
+    if (useNormalsForHashing) {
+        EachGeometryAttribute(Body);
+    }
+    else {
+        EachGeometryAttributeExceptNormals(Body);
+    }
 #undef Body
 
     // bones

--- a/Plugin~/Src/MeshSync/SceneGraph/msMesh.cpp
+++ b/Plugin~/Src/MeshSync/SceneGraph/msMesh.cpp
@@ -226,6 +226,14 @@ void BoneData::clear()
 #define EachGeometryAttribute(F)\
     EachVertexAttribute(F) EachTopologyAttribute(F)
 
+
+#define EachVertexAttributeExceptNormals(F)\
+    F(points) F(tangents) F(colors) F(velocities) \
+    F(m_uv[0]) F(m_uv[1]) F(m_uv[2]) F(m_uv[3]) F(m_uv[4]) F(m_uv[5]) F(m_uv[6]) F(m_uv[7])
+
+#define EachGeometryAttributeExceptNormals(F)\
+    EachVertexAttributeExceptNormals(F) EachTopologyAttribute(F)
+
 #define EachMember(F)\
     F(refine_settings) EachGeometryAttribute(F) F(root_bone) F(bones) F(blendshapes) F(submeshes) F(bounds)
 
@@ -502,7 +510,7 @@ uint64_t Mesh::checksumGeom() const
     uint64_t ret = 0;
     ret += refine_settings.checksum();
 #define Body(A) ret += csum(A);
-    EachGeometryAttribute(Body);
+    EachGeometryAttributeExceptNormals(Body);
 #undef Body
 
     // bones


### PR DESCRIPTION
We get normals from blender. Sometimes there are floating point errors, which cause them to be different and cause meshsync to trigger syncs when nothing changed.
I tried rounding the floats to avoid this but it still happens in some cases.
I think the only way we can deal with this is to not use normals for the hash check to see if meshes have changed. I believe this is acceptable because when the mesh really changes, more than just normals would change, so this should not be a problem.