### PR TITLE
[For 0.18.x] fix: Instancing fixes

### DIFF
--- a/Runtime/Scripts/BaseMeshSync.Modifiers.cs
+++ b/Runtime/Scripts/BaseMeshSync.Modifiers.cs
@@ -349,6 +349,7 @@ partial class BaseMeshSync {
     }
 
     [SerializeField] private InstanceHandlingType instanceHandling = InstanceHandlingType.InstanceRenderer;
+    Dictionary<string, HashSet<string>> instancesReceivedLastUpdate = new Dictionary<string, HashSet<string>>();
 
     private int numberOfPropertiesReceived;
 

--- a/Runtime/Scripts/BaseMeshSync.cs
+++ b/Runtime/Scripts/BaseMeshSync.cs
@@ -2358,11 +2358,6 @@ public abstract partial class BaseMeshSync : MonoBehaviour, IObservable<MeshSync
         for (int x = 0; x < 3; x++)
         for (int y = 0; y < 3; y++)
         {
-            if (Math.Abs(localMatrix[x, y] - converted[x, y]) > 0.01f)
-            {
-                int zzzz = 0;
-                zzzz++;
-            }
             Debug.Assert(Math.Abs(localMatrix[x, y] - converted[x, y]) < 0.01f, "Matrices don't match!");
         }
 #endif

--- a/Runtime/Scripts/BaseMeshSync.cs
+++ b/Runtime/Scripts/BaseMeshSync.cs
@@ -515,6 +515,7 @@ public abstract partial class BaseMeshSync : MonoBehaviour, IObservable<MeshSync
         CheckForNewSession(mes);
 
         numberOfPropertiesReceived = 0;
+        instancesReceivedLastUpdate.Clear();
     }
 
     public void ForceDeleteChildrenInNextSession() {
@@ -680,7 +681,7 @@ public abstract partial class BaseMeshSync : MonoBehaviour, IObservable<MeshSync
                 if (src.entityType != EntityType.Mesh)
                     continue;
                 
-                EntityRecord  dst = UpdateInstancedEntity(src);
+                EntityRecord dst = UpdateInstancedEntity(src);
 
                 if (dst == null) return;
 
@@ -775,13 +776,35 @@ public abstract partial class BaseMeshSync : MonoBehaviour, IObservable<MeshSync
 
         // resolve references
         // this must be another pass because resolving bones can affect references
-        foreach (KeyValuePair<string, EntityRecord> kvp in m_clientObjects) {
+        foreach (KeyValuePair<string, EntityRecord> kvp in m_clientObjects)
+        {
             EntityRecord rec = kvp.Value;
-            if (!string.IsNullOrEmpty(rec.reference)) {
-                EntityRecord srcrec = null;
-                if (m_clientObjects.TryGetValue(rec.reference, out srcrec) && srcrec.go != null) {
-                    rec.materialIDs = srcrec.materialIDs;
-                    UpdateReference(rec, srcrec, GetConfigV());
+            UpdateReference(rec);
+        }
+        
+        // Check for dead instances and delete them:
+        foreach (var clientInstance in m_clientInstances)
+        {
+            var instancedObjectPath = clientInstance.Key;
+            var instanceInfo = clientInstance.Value;
+
+            foreach (var parentPath in instanceInfo.parentPaths)
+            {
+                if (instancesReceivedLastUpdate.TryGetValue(instancedObjectPath, out var parentList))
+                {
+                    if (parentList.Contains(parentPath))
+                        continue;
+
+                    // The instance for this parent was not updated, remove it:
+                    var parent =
+                        FilmInternalUtilities.GameObjectUtility.FindByPath(m_rootObject, parentPath);
+
+                    EraseInstanceInfoRecord(instanceInfo, parent);
+                }
+                else
+                {
+                    // The instance was not sent at all, remove it from all parents:
+                    EraseInstanceInfoRecord(instanceInfo, null);
                 }
             }
         }
@@ -821,6 +844,19 @@ public abstract partial class BaseMeshSync : MonoBehaviour, IObservable<MeshSync
 
         if (onSceneUpdateEnd != null)
             onSceneUpdateEnd.Invoke();
+    }
+
+    void UpdateReference(EntityRecord rec)
+    {
+        if (!string.IsNullOrEmpty(rec.reference))
+        {
+            EntityRecord srcrec = null;
+            if (m_clientObjects.TryGetValue(rec.reference, out srcrec) && srcrec.go != null)
+            {
+                rec.materialIDs = srcrec.materialIDs;
+                UpdateReference(rec, srcrec, GetConfigV());
+            }
+        }
     }
 
     //----------------------------------------------------------------------------------------------------------------------
@@ -1992,12 +2028,15 @@ public abstract partial class BaseMeshSync : MonoBehaviour, IObservable<MeshSync
         rec.SetLight(data, config.SyncVisibility, syncLightSettings.CanUpdate);
         return rec;
     }
-
+    
     private void UpdateReference(EntityRecord dst, EntityRecord src, MeshSyncPlayerConfig config) {
         if (src.dataType == EntityType.Unknown) {
             Debug.LogError("MeshSync: should not be here!");
             return;
         }
+
+        // Objects with references are passed as transforms, update the type to match the reference:
+        dst.dataType = src.dataType;
 
         GameObject dstgo = dst.go;
         GameObject srcgo = src.go;
@@ -2135,8 +2174,11 @@ public abstract partial class BaseMeshSync : MonoBehaviour, IObservable<MeshSync
         if (m_clientInstances.TryGetValue(data.path, out InstanceInfoRecord infoRecord)) {
             // Update the renderer reference
             infoRecord.go = rec.go;
-            MeshSyncInstanceRenderer renderer = infoRecord.renderer;
-            if (renderer != null) renderer.UpdateReference(rec.go);
+
+            foreach (var renderer in infoRecord.renderers)
+            {
+                if (renderer != null) renderer.UpdateReference(rec.go);
+            }
         }
 
         return rec;
@@ -2144,14 +2186,25 @@ public abstract partial class BaseMeshSync : MonoBehaviour, IObservable<MeshSync
 
     private HashSet<string> instanceNames = new HashSet<string>();
 
-    private InstanceInfoRecord UpdateInstanceInfo(InstanceInfoData data) {
+    private InstanceInfoRecord UpdateInstanceInfo(InstanceInfoData data)
+    {
         string path = data.path;
 
+        if (!instancesReceivedLastUpdate.TryGetValue(data.path, out var parentList))
+        {
+            parentList = new HashSet<string>();
+            instancesReceivedLastUpdate[data.path] = parentList;
+        }
+        parentList.Add(data.parentPath);
+
         InstanceInfoRecord infoRecord;
-        if (!m_clientInstances.TryGetValue(path, out infoRecord)) {
+        if (!m_clientInstances.TryGetValue(path, out infoRecord))
+        {
             infoRecord = new InstanceInfoRecord();
             m_clientInstances.Add(path, infoRecord);
         }
+
+        infoRecord.parentPaths.Add(data.parentPath);
 
         EntityRecord instancedEntityRecord;
         // Look for reference in client instanced objects
@@ -2164,23 +2217,29 @@ public abstract partial class BaseMeshSync : MonoBehaviour, IObservable<MeshSync
 
         // Find parent for this instance:
         GameObject instanceRendererParent;
-        if (m_clientObjects.TryGetValue(data.parentPath, out EntityRecord parentRecord)) {
+        if (m_clientObjects.TryGetValue(data.parentPath, out EntityRecord parentRecord))
+        {
             instanceRendererParent = parentRecord.go;
         }
-        else {
+        else
+        {
             instanceRendererParent = m_rootObject.gameObject;
 
             Debug.LogWarningFormat(
                 "[MeshSync] No entity found for parent path {0}, using root as parent", data.parentPath);
         }
 
+        // Ensure references are updated
+        UpdateReference(instancedEntityRecord);
+        
         // Anything other than a mesh needs to use copies if we're in instance renderer mode:
         InstanceHandlingType instanceHandlingToUse = InstanceHandling;
         if (instanceHandlingToUse == InstanceHandlingType.InstanceRenderer &&
             instancedEntityRecord.dataType != EntityType.Mesh)
             instanceHandlingToUse = InstanceHandlingType.Copies;
 
-        switch (instanceHandlingToUse) {
+        switch (instanceHandlingToUse)
+        {
             case InstanceHandlingType.InstanceRenderer:
                 UpdateInstanceInfo_InstanceRenderer(data, infoRecord, instanceRendererParent);
                 break;
@@ -2194,23 +2253,26 @@ public abstract partial class BaseMeshSync : MonoBehaviour, IObservable<MeshSync
 
         return infoRecord;
     }
-    
+
     private void UpdateInstanceInfo_CopiesAndPrefabs(
         InstanceInfoData data,
         InstanceInfoRecord infoRecord,
-        GameObject instanceRendererParent) {
+        GameObject instanceRendererParent)
+    {
         // Make sure the other renderer is removed if this was not a copy or prefab before:
-        if (infoRecord.renderer != null) {
-            DestroyImmediate(infoRecord.renderer);
-            infoRecord.renderer = null;
+        foreach (var meshSyncInstanceRenderer in infoRecord.renderers)
+        {
+            DestroyImmediate(meshSyncInstanceRenderer);
         }
-
-        infoRecord.DeleteInstanceObjects();
+        infoRecord.renderers.Clear();
 
         instanceNames.Add(infoRecord.go.name);
         
         if (infoRecord.go.transform.parent == null ||
-            !instanceNames.Contains(infoRecord.go.transform.parent.name)) {
+            !instanceNames.Contains(infoRecord.go.transform.parent.name))
+        {
+            infoRecord.DeleteInstanceObjects(instanceRendererParent.transform);
+
             GameObject instanceObjectOriginal;
             if (InstanceHandling == InstanceHandlingType.Prefabs)
                 instanceObjectOriginal = GetOrCreatePrefab(data, infoRecord);
@@ -2219,9 +2281,11 @@ public abstract partial class BaseMeshSync : MonoBehaviour, IObservable<MeshSync
 
             if (instanceObjectOriginal == null) return;
 
-            foreach (Matrix4x4 mat in data.transforms) {
+            foreach (Matrix4x4 mat in data.transforms)
+            {
                 GameObject instancedCopy;
-                if (InstanceHandling == InstanceHandlingType.Prefabs) {
+                if (InstanceHandling == InstanceHandlingType.Prefabs)
+                {
 #if UNITY_EDITOR
                     instancedCopy = (GameObject)PrefabUtility.InstantiatePrefab(instanceObjectOriginal,
                         instanceRendererParent.transform);
@@ -2229,7 +2293,8 @@ public abstract partial class BaseMeshSync : MonoBehaviour, IObservable<MeshSync
                         instancedCopy = Instantiate(instanceObjectOriginal, instanceRendererParent.transform);
 #endif
                 }
-                else {
+                else
+                {
                     instancedCopy = Instantiate(instanceObjectOriginal, instanceRendererParent.transform);
                 }
 
@@ -2242,48 +2307,100 @@ public abstract partial class BaseMeshSync : MonoBehaviour, IObservable<MeshSync
                 infoRecord.instanceObjects.Add(instancedCopy);
             }
         }
-        else {
-            // This instance exists inside another instanced object,
-            // update its transform to be correct relative to the parent on the infoRecord:
-            // For example, in an object structure like this:
-            // MainObject
-            //   InstancedChildA
-            //     InstancedChildB
-            // For the instance renderer method, InstancedChildA and InstancedChildB exist as
-            // MeshSyncInstanceRenderer components on MainObject and the transforms in data.transforms
-            // are relative to MainObject. 
-            // In this mode, where we use copies of the objects, InstancedChildB already exists as child of InstancedChildA
-            // but the transform of InstancedChildB needs to be updated to be relative to MainObject.
+        else
+        {
+            var originalInstanceGoParent = infoRecord.go.transform.parent;
+            // If the instance is already in the scene as a child of another instance,
+            // match the child to the corresponding parent and set its transform:
+            if (originalInstanceGoParent != null &&
+                instanceNames.Contains(originalInstanceGoParent.name))
+            {
+                var originalInstanceGoParentPath = BuildPath(originalInstanceGoParent); // BuildPathFromObjectHierarchy(originalInstanceGoParent);
+                if (m_clientInstances.TryGetValue(originalInstanceGoParentPath, out var parentInfoRecord))
+                {
+                    return;
+                    Debug.Assert(parentInfoRecord.instanceObjects.Count == data.transforms.Length,
+                        "The number of instances of the instanced parent and its children should match");
 
-            if (data.transforms.Length != 1) {
-                Debug.LogWarning(
-                    $"[MeshSync] There should never be more than 1 transform on instances inside other instances: {data.path}");
-                return;
+                    // Set the transforms:
+                    for (int i = 0; i < data.transforms.Length; i++)
+                    {
+                        var instanceParent = parentInfoRecord.instanceObjects[i];
+
+                        var instancedCopy = instanceParent.transform.Find(infoRecord.go.name);
+                        EnableInstancedCopy(instancedCopy.gameObject);
+                        
+                        SetInstanceTransformRelative(instanceRendererParent, instancedCopy, ref data.transforms[i]);
+                    }
+                }
             }
+            else
+            {
+                // This instance exists inside another instanced object,
+                // update its transform to be correct relative to the parent on the infoRecord:
+                // For example, in an object structure like this:
+                // MainObject
+                //   InstancedChildA
+                //     InstancedChildB
+                // For the instance renderer method, InstancedChildA and InstancedChildB exist as
+                // MeshSyncInstanceRenderer components on MainObject and the transforms in data.transforms
+                // are relative to MainObject. 
+                // In this mode, where we use copies of the objects, InstancedChildB already exists as child of InstancedChildA
+                // but the transform of InstancedChildB needs to be updated to be relative to MainObject.
 
-            // Find the instanced copy as (a potentially indirect) child of `MainObject`:
-            var instancedCopy =
-                FilmInternalUtilities.GameObjectUtility.FindByPath(instanceRendererParent.transform, data.path);
+                // if (data.transforms.Length != 1) {
+                //     Debug.LogWarning(
+                //         $"[MeshSync] There should never be more than 1 transform on instances inside other instances: {data.path}");
+                //     return;
+                // }
 
-            if (instancedCopy == null) {
-                Debug.LogWarning(
-                    $"[MeshSync] No instanced copy found for {data.path}");
-                return;
+                // Find the instanced copy as (a potentially indirect) child of `MainObject`:
+                var instancedCopy =
+                    FilmInternalUtilities.GameObjectUtility.FindByPath(instanceRendererParent.transform, data.path);
+
+                if (instancedCopy == null)
+                {
+                    Debug.LogWarning(
+                        $"[MeshSync] No instanced copy found for {data.path}");
+                    return;
+                }
+
+                SetInstanceTransformRelative(instanceRendererParent, instancedCopy, ref data.transforms[0]);
+                // // Set the transform relative to `MainObject`.
+                // // The easiest and safest way to do that is to:
+                // // - parent the instanced copy to `MainObject`
+                // // - set the transform matrix
+                // // - restore the original parent
+                // var originalParent = instancedCopy.parent;
+                //
+                // instancedCopy.transform.SetParent(instanceRendererParent.transform);
+                //
+                // // for (int i = 0; i < data.transforms.Length; i++)
+                // {
+                //     SetInstanceTransform(instancedCopy.gameObject, instanceRendererParent, data.transforms[0]);
+                // }
+                //
+                // instancedCopy.SetParent(originalParent);
             }
-
-            // Set the transform relative to `MainObject`.
-            // The easiest and safest way to do that is to:
-            // - parent the instanced copy to `MainObject`
-            // - set the transform matrix
-            // - restore the original parent
-            var originalParent = instancedCopy.parent;
-
-            instancedCopy.transform.SetParent(instanceRendererParent.transform);
-
-            SetInstanceTransform(instancedCopy.gameObject, instanceRendererParent, data.transforms[0]);
-
-            instancedCopy.SetParent(originalParent);
         }
+    }
+
+    static void SetInstanceTransformRelative(
+        GameObject instanceRendererParent,
+        Transform instancedCopy,
+        ref Matrix4x4 mat)
+    {
+        // Set the transform relative to the parent of the instance.
+        // The easiest and safest way to do that is to:
+        // - parent the instanced copy to the parent of the instance
+        // - set the transform matrix
+        // - restore the original parent
+        var originalParent = instancedCopy.parent;
+        instancedCopy.transform.SetParent(instanceRendererParent.transform);
+
+        SetInstanceTransform(instancedCopy.gameObject, instanceRendererParent, mat);
+
+        instancedCopy.SetParent(originalParent);
     }
 
     private void EnableInstancedCopy(GameObject obj) {
@@ -2359,14 +2476,40 @@ public abstract partial class BaseMeshSync : MonoBehaviour, IObservable<MeshSync
         return instanceObject;
     }
 
-    private static void UpdateInstanceInfo_InstanceRenderer(InstanceInfoData data, InstanceInfoRecord infoRecord,
-        GameObject instanceRendererParent) {
+    private static void UpdateInstanceInfo_InstanceRenderer(
+        InstanceInfoData data,
+        InstanceInfoRecord infoRecord,
+        GameObject instanceRendererParent)
+    {
         infoRecord.DeleteInstanceObjects();
 
-        if (instanceRendererParent != null && infoRecord.renderer == null)
-            infoRecord.renderer = instanceRendererParent.AddComponent<MeshSyncInstanceRenderer>();
+        if (instanceRendererParent != null)
+        {
+            var existingRenderers = instanceRendererParent.GetComponents<MeshSyncInstanceRenderer>();
 
-        infoRecord.renderer.UpdateAll(data.transforms, infoRecord.go);
+            bool hasRenderer = false;
+            foreach (var existingRenderer in existingRenderers)
+            {
+                if (infoRecord.renderers.Contains(existingRenderer))
+                {
+                    hasRenderer = true;
+                    break;
+                }
+            }
+
+            if (!hasRenderer)
+            {
+                infoRecord.renderers.Add(instanceRendererParent.AddComponent<MeshSyncInstanceRenderer>());
+            }
+        }
+
+        foreach (var renderer in infoRecord.renderers)
+        {
+            if (renderer.gameObject != instanceRendererParent)
+                continue;
+
+            renderer.UpdateAll(data.transforms, infoRecord.go);
+        }
     }
 
     private void UpdateConstraint(ConstraintData data) {
@@ -2528,9 +2671,9 @@ public abstract partial class BaseMeshSync : MonoBehaviour, IObservable<MeshSync
 
             if (m_clientInstances.TryGetValue(rec.Key, out var instanceInfoRecord))
             {
-                if (instanceInfoRecord.renderer != null)
+                foreach (var meshSyncInstanceRenderer in instanceInfoRecord.renderers)
                 {
-                    instanceInfoRecord.renderer.UpdateMaterials();
+                    if (meshSyncInstanceRenderer != null) meshSyncInstanceRenderer.UpdateMaterials();
                 }
                 
                 foreach (var instancedCopy in instanceInfoRecord.instanceObjects)
@@ -2603,18 +2746,37 @@ public abstract partial class BaseMeshSync : MonoBehaviour, IObservable<MeshSync
         return ret;
     }
 
+    internal void EraseInstanceInfoRecord(
+        InstanceInfoRecord record,
+        Transform parentFilter)
+    {
+        for (var i = record.renderers.Count - 1; i >= 0; i--)
+        {
+            var meshSyncInstanceRenderer = record.renderers[i];
+            if (parentFilter == null || meshSyncInstanceRenderer.transform == parentFilter)
+            {
+                DestroyImmediate(meshSyncInstanceRenderer);
+                record.renderers.RemoveAt(i);
+            }
+        }
+
+        record.DeleteInstanceObjects(parentFilter);
+    }
+    
     internal bool EraseInstanceInfoRecord(Identifier identifier) {
         return EraseInstanceRecord(identifier, m_clientInstances,
             delegate(InstanceInfoRecord record) {
-                DestroyImmediate(record.renderer);
-
+                foreach (var meshSyncInstanceRenderer in record.renderers)
+                {
+                    DestroyImmediate(meshSyncInstanceRenderer);
+                }
                 record.DeleteInstanceObjects();
 
                 if (onDeleteInstanceInfo != null)
                     onDeleteInstancedEntity(identifier.name);
             });
     }
-
+    
     internal bool EraseInstancedEntityRecord(Identifier identifier) {
         return EraseInstanceRecord(identifier, m_clientInstancedEntities,
             delegate(EntityRecord record) {
@@ -3133,12 +3295,12 @@ public abstract partial class BaseMeshSync : MonoBehaviour, IObservable<MeshSync
     private List<IObserver<MeshSyncAnalyticsData>> m_observers = new List<IObserver<MeshSyncAnalyticsData>>();
     private Material                               m_cachedDefaultMaterial;
 
-    private readonly           Dictionary<string, EntityRecord> m_clientObjects = new Dictionary<string, EntityRecord>();
+    private protected readonly Dictionary<string, EntityRecord> m_clientObjects = new Dictionary<string, EntityRecord>();
     private protected readonly Dictionary<int, EntityRecord>    m_hostObjects   = new Dictionary<int, EntityRecord>();
     private readonly           Dictionary<GameObject, int>      m_objIDTable    = new Dictionary<GameObject, int>();
 
     [SerializeField] private protected InstanceInfoRecordDictionary m_clientInstances         = new InstanceInfoRecordDictionary();
-    [SerializeField] private           EntityRecordDictionary       m_clientInstancedEntities = new EntityRecordDictionary();
+    [SerializeField] private protected EntityRecordDictionary       m_clientInstancedEntities = new EntityRecordDictionary();
 
     private protected Action m_onMaterialChangedInSceneViewCB = null;
 

--- a/Runtime/Scripts/BaseMeshSync.cs
+++ b/Runtime/Scripts/BaseMeshSync.cs
@@ -856,6 +856,17 @@ public abstract partial class BaseMeshSync : MonoBehaviour, IObservable<MeshSync
                 rec.materialIDs = srcrec.materialIDs;
                 UpdateReference(rec, srcrec, GetConfigV());
             }
+            // else if(m_clientInstancedEntities.TryGetValue(rec.reference, out srcrec) && srcrec.go != null)
+            // {
+            //     rec.materialIDs = srcrec.materialIDs;
+            //     UpdateReference(rec, srcrec, GetConfigV());
+            // }
+            
+            // if(srcrec.go!=null)
+            // { 
+            //         rec.materialIDs = srcrec.materialIDs;
+            //         UpdateReference(rec, srcrec, GetConfigV()); 
+            // }
         }
     }
 
@@ -2307,24 +2318,6 @@ public abstract partial class BaseMeshSync : MonoBehaviour, IObservable<MeshSync
                 infoRecord.instanceObjects.Add(instancedCopy);
             }
         }
-    }
-
-    static void SetInstanceTransformRelative(
-        GameObject instanceRendererParent,
-        Transform instancedCopy,
-        ref Matrix4x4 mat)
-    {
-        // Set the transform relative to the parent of the instance.
-        // The easiest and safest way to do that is to:
-        // - parent the instanced copy to the parent of the instance
-        // - set the transform matrix
-        // - restore the original parent
-        var originalParent = instancedCopy.parent;
-        instancedCopy.transform.SetParent(instanceRendererParent.transform);
-
-        SetInstanceTransform(instancedCopy.gameObject, instanceRendererParent, mat);
-
-        instancedCopy.SetParent(originalParent);
     }
 
     private void EnableInstancedCopy(GameObject obj) {

--- a/Runtime/Scripts/MeshSyncInstanceRenderer.cs
+++ b/Runtime/Scripts/MeshSyncInstanceRenderer.cs
@@ -3,6 +3,7 @@
 using UnityEditor.Experimental.SceneManagement;
 #endif
 #endif
+using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.Rendering;
 
@@ -14,6 +15,8 @@ internal class MeshSyncInstanceRenderer : MonoBehaviour {
     [HideInInspector] [SerializeField] private Matrix4x4[] transforms;
     [SerializeField]                   private GameObject  reference;
 
+    [HideInInspector] public List<MeshSyncInstanceRenderer> ParentRenderers = new List<MeshSyncInstanceRenderer>(); 
+    
     public int TransformCount {
         get { return transforms.Length; }
     }
@@ -91,6 +94,20 @@ internal class MeshSyncInstanceRenderer : MonoBehaviour {
         info.instances      = transforms;
         info.gameObject     = reference;
         info.instanceParent = transform;
+    }
+
+    public void UpdateFromExistingInstanceRenderer(MeshSyncInstanceRenderer child, InstanceInfoData data)
+    {
+        var combinedTransforms = new Matrix4x4[data.transforms.Length * child.transforms.Length];
+        for (int i = 0; i < data.transforms.Length; i++)
+        {
+            for (int j = 0; j < child.transforms.Length; j++)
+            {
+                combinedTransforms[i * child.transforms.Length + j] = data.transforms[i] * child.transforms[j];      
+            }
+        }
+                
+        UpdateAll(combinedTransforms, child.reference);
     }
 
     #endregion

--- a/Runtime/Scripts/MeshSyncServer.Properties.cs
+++ b/Runtime/Scripts/MeshSyncServer.Properties.cs
@@ -30,6 +30,10 @@ partial class MeshSyncServer {
                 base.InstanceHandling = value;
 
                 ClearInstancePrefabs();
+                
+                m_clientInstances.Clear();
+                m_clientInstancedEntities.Clear();
+                m_clientObjects.Clear();
             }
         }
     }
@@ -61,7 +65,10 @@ partial class MeshSyncServer {
             foreach (KeyValuePair<string, InstanceInfoRecord> inst in m_clientInstances) {
                 count += inst.Value.instanceObjects.Count;
 
-                if (inst.Value.renderer != null) count += inst.Value.renderer.TransformCount;
+                foreach (var renderer in inst.Value.renderers)
+                {
+                    if (renderer != null) count += renderer.TransformCount; 
+                }
             }
 
             return count;

--- a/Runtime/Scripts/PlayerData/InstanceInfoRecord.cs
+++ b/Runtime/Scripts/PlayerData/InstanceInfoRecord.cs
@@ -6,13 +6,34 @@ namespace Unity.MeshSync {
 [Serializable]
 internal class InstanceInfoRecord {
     public GameObject               go;
-    public MeshSyncInstanceRenderer renderer;
+    public List<MeshSyncInstanceRenderer> renderers = new List<MeshSyncInstanceRenderer>();
     public List<GameObject>         instanceObjects = new List<GameObject>();
+    public List<string>             parentPaths = new List<string>();
 
-    public void DeleteInstanceObjects() {
-        foreach (GameObject obj in instanceObjects) UnityEngine.Object.DestroyImmediate(obj);
+    public void DeleteInstanceObjects(Transform parentFilter = null) {
+        if (parentFilter == null)
+        {
+            foreach (GameObject obj in instanceObjects)
+            {
+                UnityEngine.Object.DestroyImmediate(obj);
+            }
 
-        instanceObjects.Clear();
+            instanceObjects.Clear();
+        }
+        else
+        {
+            for (var i = instanceObjects.Count - 1; i >= 0; i--)
+            {
+                var obj = instanceObjects[i];
+                if (obj == null || parentFilter != obj.transform.parent)
+                {
+                    continue;
+                }
+
+                UnityEngine.Object.DestroyImmediate(obj);
+                instanceObjects.RemoveAt(i);
+            }
+        }
     }
 }
 }


### PR DESCRIPTION
We had an architectural problem with the way we send instances, which this PR addresses.
Previously we sent one instance info for each instance, which caused problems when the same object is instanced on multiple parents.
With these changes each instance has a collection of parents it appears on, which allows us to parent the instances to the correct parent and allows us to do nested instances correctly.