### PR TITLE
change: put any child objects we create on the same layer as the server

### DIFF
--- a/Runtime/Scripts/BaseMeshSync.cs
+++ b/Runtime/Scripts/BaseMeshSync.cs
@@ -1773,7 +1773,7 @@ public abstract partial class BaseMeshSync : MonoBehaviour, IObservable<MeshSync
                 t = go.GetComponent<Transform>();
 
                 if (gameObjectLayer != -1) {
-                    go.layer = gameObjectLayer;// m_rootObject.gameObject.layer;
+                    go.layer = gameObjectLayer;
                 }
             }
 
@@ -1790,7 +1790,7 @@ public abstract partial class BaseMeshSync : MonoBehaviour, IObservable<MeshSync
             GameObject go = new GameObject(childName);
 
             if (gameObjectLayer != -1) {
-                go.layer = gameObjectLayer;// m_rootObject.gameObject.layer;
+                go.layer = gameObjectLayer;
             }
             
             childT = go.transform;

--- a/Runtime/Scripts/BaseMeshSync.cs
+++ b/Runtime/Scripts/BaseMeshSync.cs
@@ -1753,7 +1753,11 @@ public abstract partial class BaseMeshSync : MonoBehaviour, IObservable<MeshSync
         return rec;
     }
 
-    private Transform FindOrCreateByPath(Transform parent, string path, Action<string> parentCreationCallback, bool worldPositionStays = true) {
+    static Transform FindOrCreateByPath(Transform parent, 
+        string path,
+        Action<string> parentCreationCallback,
+        bool worldPositionStays = true, 
+        int gameObjectLayer = -1) {
         string[] names = path.Split('/');
         if (names.Length <= 0)
             return null;
@@ -1767,9 +1771,10 @@ public abstract partial class BaseMeshSync : MonoBehaviour, IObservable<MeshSync
             if (null == t) {
                 GameObject go = new GameObject(rootGameObjectName);
                 t = go.GetComponent<Transform>();
-                
-                // Ensure any objects we create are on the same layer as the server:
-                go.layer = m_rootObject.gameObject.layer;
+
+                if (gameObjectLayer != -1) {
+                    go.layer = gameObjectLayer;// m_rootObject.gameObject.layer;
+                }
             }
 
             tokenStartIdx = 1;
@@ -1783,8 +1788,10 @@ public abstract partial class BaseMeshSync : MonoBehaviour, IObservable<MeshSync
             }
 
             GameObject go = new GameObject(childName);
-            // Ensure any objects we create are on the same layer as the server:
-            go.layer = m_rootObject.gameObject.layer;
+
+            if (gameObjectLayer != -1) {
+                go.layer = gameObjectLayer;// m_rootObject.gameObject.layer;
+            }
             
             childT = go.transform;
             childT.SetParent(t, worldPositionStays);
@@ -1834,7 +1841,8 @@ public abstract partial class BaseMeshSync : MonoBehaviour, IObservable<MeshSync
                     if (parentRec.dataType == EntityType.Unknown)
                         parentRec.dataType = EntityType.Transform;
                 },
-                false);
+                false,
+                m_rootObject.gameObject.layer);
 
             rec = new EntityRecord {
                 go     = trans.gameObject,

--- a/Runtime/Scripts/BaseMeshSync.cs
+++ b/Runtime/Scripts/BaseMeshSync.cs
@@ -1753,7 +1753,7 @@ public abstract partial class BaseMeshSync : MonoBehaviour, IObservable<MeshSync
         return rec;
     }
 
-    static Transform FindOrCreateByPath(Transform parent, string path, Action<string> parentCreationCallback, bool worldPositionStays = true) {
+    private Transform FindOrCreateByPath(Transform parent, string path, Action<string> parentCreationCallback, bool worldPositionStays = true) {
         string[] names = path.Split('/');
         if (names.Length <= 0)
             return null;
@@ -1767,12 +1767,15 @@ public abstract partial class BaseMeshSync : MonoBehaviour, IObservable<MeshSync
             if (null == t) {
                 GameObject go = new GameObject(rootGameObjectName);
                 t = go.GetComponent<Transform>();
+                
+                // Ensure any objects we create are on the same layer as the server:
+                go.layer = m_rootObject.gameObject.layer;
             }
 
             tokenStartIdx = 1;
         }
 
-        static Transform FindOrCreateChild(Transform t, string childName, out bool didCreate, bool worldPositionStays = true) {
+        Transform FindOrCreateChild(Transform t, string childName, out bool didCreate, bool worldPositionStays = true) {
             Transform childT = t.Find(childName);
             if (null != childT) {
                 didCreate = false;
@@ -1780,6 +1783,9 @@ public abstract partial class BaseMeshSync : MonoBehaviour, IObservable<MeshSync
             }
 
             GameObject go = new GameObject(childName);
+            // Ensure any objects we create are on the same layer as the server:
+            go.layer = m_rootObject.gameObject.layer;
+            
             childT = go.transform;
             childT.SetParent(t, worldPositionStays);
             didCreate = true;
@@ -2122,7 +2128,9 @@ public abstract partial class BaseMeshSync : MonoBehaviour, IObservable<MeshSync
         if (!m_clientInstancedEntities.TryGetValue(data.path, out EntityRecord rec) || rec.go == null) {
             Transform trans =
                 FilmInternalUtilities.GameObjectUtility.FindOrCreateByPath(m_rootObject, data.path, false);
-
+        
+            // Ensure any objects we create are on the same layer as the server:
+            trans.gameObject.layer = m_rootObject.gameObject.layer;
             rec = new EntityRecord {
                 go     = trans.gameObject,
                 trans  = trans,


### PR DESCRIPTION
When running the generator from scripts, we need to make sure any child objects we create are put on the same layer as the server's root object.