### PR TITLE
change: send all instanced meshes at once to avoid instance display issues

### DIFF
--- a/Plugin~/Src/MeshSync/AsyncSceneSender.cpp
+++ b/Plugin~/Src/MeshSync/AsyncSceneSender.cpp
@@ -220,15 +220,13 @@ void AsyncSceneSender::send()
 
     //instance meshes
     if (!instanceMeshes.empty()) {
-        for (auto& mesh : instanceMeshes) {
-            ms::SetMessage mes;
-            setup_message(mes);
-            mes.scene->settings = scene_settings;
-            mes.scene->instanceMeshes = { mesh };
-            succeeded = succeeded && client.send(mes);
-            if (!succeeded)
-                goto cleanup;
-        }
+        ms::SetMessage mes;
+        setup_message(mes);
+        mes.scene->settings = scene_settings;
+        mes.scene->instanceMeshes = instanceMeshes;
+        succeeded = succeeded && client.send(mes);
+        if (!succeeded)
+            goto cleanup;
     }
 
     // instance infos


### PR DESCRIPTION
We used to send instanced meshes one at a time but it's faster to send them all in the same request. This avoids problems in Unity where instances are popping in one after another.